### PR TITLE
Updated the cli to generate non-zero exit code if issues are detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Removed
 
+## [2.1.0] - 2017-04-09
+### Changed
+- CLI process exit code to 2 (non-zero) if issues are detected in the scan
+
 ## [2.0.2] - 2017-02-18
 ### Fixed
 - Issue .npmpackagejsonlintrc.json files that only have a extends value with no rules object

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-package-json-lint",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "CLI app for linting package.json files.",
   "keywords": [
     "lint",
@@ -33,9 +33,9 @@
     "validator": "^6.2.1"
   },
   "devDependencies": {
-    "eslint": "^3.15.0",
-    "eslint-config-tc": "^1.4.0",
-    "eslint-formatter-pretty": "^1.0.0",
+    "eslint": "^3.19.0",
+    "eslint-config-tc": "^1.5.0",
+    "eslint-formatter-pretty": "^1.1.0",
     "grunt": "^1.0.1",
     "grunt-bump": "^0.8.0",
     "grunt-contrib-clean": "^1.0.0",
@@ -48,7 +48,7 @@
     "grunt-jsonlint": "^1.1.0",
     "grunt-mocha-test": "^0.13.2",
     "mocha": "^3.2.0",
-    "should": "^11.2.0",
+    "should": "^11.2.1",
     "sinon": "^1.17.7",
     "time-grunt": "^1.4.0"
   },

--- a/src/cli.js
+++ b/src/cli.js
@@ -81,6 +81,8 @@ let fileData = null;
 
 try {
   let exitCode = 0;
+  const noIssues = 0;
+  const issuesDetectedErrorCode = 2;
   const parser = new Parser();
 
   fileData = parser.parse(filePath);
@@ -92,8 +94,8 @@ try {
   for (const issueType in output) {
     const issues = output[issueType];
 
-    if (issues.length > 0) {
-      exitCode = 2;
+    if (issues.length > noIssues) {
+      exitCode = issuesDetectedErrorCode;
       reporter.write(output[issueType], issueType);
     }
   }

--- a/src/cli.js
+++ b/src/cli.js
@@ -80,23 +80,27 @@ if (!rulesLoaded) {
 let fileData = null;
 
 try {
+  let exitCode = 0;
   const parser = new Parser();
 
   fileData = parser.parse(filePath);
 
   const npmPackageJsonLint = new NpmPackageJsonLint(fileData, rulesConfig, options);
   const output = npmPackageJsonLint.lint();
-
   const reporter = new Reporter();
 
   for (const issueType in output) {
     const issues = output[issueType];
 
-    reporter.write(output[issueType], issueType);
+    if (issues.length > 0) {
+      exitCode = 2;
+      reporter.write(output[issueType], issueType);
+    }
   }
 
   const formattedFileName = chalk.bold.green(filePath);
 
+  process.exitCode = exitCode;
   console.log(`${formattedFileName} check complete`);
 } catch (err) {
   handleError(err);


### PR DESCRIPTION
Fixes #25

CLI will now exit with an exit code of 2 if issues are detected during
the scan.
Bumped version to 2.1.0 and bumped underlying dependencies.