### PR TITLE
Update array style rules so they can easily be turned off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Removed
 
+## [2.1.2] - 2017-04-10
+### Fixed
+- Array style rules, like `valid-values-author`, so they can be easily turned off by setting `valid-values-author: 'off'`
+
 ## [2.1.1] - 2017-04-10
 ### Fixed
 - CLI so process exit code remains 0 if only warnings are detected

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-package-json-lint",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "CLI app for linting package.json files.",
   "keywords": [
     "lint",

--- a/src/NpmPackageJsonLint.js
+++ b/src/NpmPackageJsonLint.js
@@ -37,7 +37,7 @@ class NpmPackageJsonLint {
       const ruleModule = this.rules.get(rule);
 
       if (inArray(this.arrayRuleTypes, ruleModule.ruleType)) {
-        const errorWarningOffSetting = configObj[rule][0];
+        const errorWarningOffSetting = typeof configObj[rule] === 'string' && configObj[rule] === 'off' ? configObj[rule] : configObj[rule][0];
         const ruleConfigArray = configObj[rule][1];
 
         if (errorWarningOffSetting !== 'off') {

--- a/tests/unit/NpmPackageJsonLintTest.js
+++ b/tests/unit/NpmPackageJsonLintTest.js
@@ -126,8 +126,8 @@ describe('NpmPackageJsonLint Unit Tests', function() {
       });
     });
 
-    context('validate that errors and warnings are set', function() {
-      it('one error and one warning expected', function() {
+    context('validate that when array style rules have an array value with off', function() {
+      it('zero errors and zero warning expected', function() {
         const packageJsonData = {
           author: 'Caitlin Snow'
         };
@@ -136,6 +136,27 @@ describe('NpmPackageJsonLint Unit Tests', function() {
             'Barry Allen',
             'Iris West'
           ]]
+        };
+        const options = {
+          ignoreWarnings: true
+        };
+        const npmPackageJsonLint = new NpmPackageJsonLint(packageJsonData, config, options);
+        const configStub = sinon.stub(npmPackageJsonLint, '_getConfig').returns(config);
+        const response = npmPackageJsonLint.lint();
+        const expectedErrorCount = 0;
+
+        response.errors.length.should.equal(expectedErrorCount);
+        response.hasOwnProperty('warnings').should.be.false();
+      });
+    });
+
+    context('validate that when array style rules have a value of off', function() {
+      it('zero errors and zero warnings expected', function() {
+        const packageJsonData = {
+          author: 'Caitlin Snow'
+        };
+        const config = {
+          'valid-values-author': 'off'
         };
         const options = {
           ignoreWarnings: true


### PR DESCRIPTION
Fixes #27 - Allows array style rules, like “valid-values-author”, so
they can be turned off by setting “valid-values-author: ‘off’”