### PR TITLE
Clean up node package contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Removed
 
+## [2.3.0] - 2017-04-22
+### Removed
+- grunt tasks, tests, and project linting files from published node module
+
 ## [2.2.0] - 2017-04-12
 ### Added
 - Add new quiet (-q) option to cli that suppresses output if no errors

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-package-json-lint",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "CLI app for linting package.json files.",
   "keywords": [
     "lint",
@@ -22,6 +22,10 @@
   "bin": {
     "pjl-cli": "src/cli.js"
   },
+  "files": [
+    "src",
+    "CONTRIBUTING.md"
+  ],
   "main": "src/NpmPackageJsonLint.js",
   "dependencies": {
     "chalk": "^1.1.3",
@@ -30,7 +34,7 @@
     "is-plain-obj": "^1.1.0",
     "semver": "^5.3.0",
     "user-home": "^2.0.0",
-    "validator": "^6.2.1"
+    "validator": "^7.0.0"
   },
   "devDependencies": {
     "eslint": "^3.19.0",
@@ -38,7 +42,7 @@
     "eslint-formatter-pretty": "^1.1.0",
     "grunt": "^1.0.1",
     "grunt-bump": "^0.8.0",
-    "grunt-contrib-clean": "^1.0.0",
+    "grunt-contrib-clean": "^1.1.0",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-env": "^0.4.4",
     "grunt-eslint": "^19.0.0",
@@ -49,7 +53,7 @@
     "grunt-mocha-test": "^0.13.2",
     "mocha": "^3.2.0",
     "should": "^11.2.1",
-    "sinon": "^1.17.7",
+    "sinon": "^2.1.0",
     "time-grunt": "^1.4.0"
   },
   "engines": {


### PR DESCRIPTION
Closes #31

- Bump package version for minor release
- Only include src and CONTRIBUTING.md in package in addition to
default files
- Bump dependencies