### PR TITLE
Closes #50 - Add support for checking package.json property order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Removed
 
+## [2.8.0] - 2017-08-16
+### Added
+- New rule: [prefer-property-order](https://github.com/tclindner/npm-package-json-lint/wiki/prefer-property-order)
+
 ## [2.7.1] - 2017-08-15
 ### Fixed
 - [Issue #48](https://github.com/tclindner/npm-package-json-lint/issues/48) [valid-values-license](https://github.com/tclindner/npm-package-json-lint/wiki/valid-values-license)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-package-json-lint",
-  "version": "2.7.1",
+  "version": "2.8.0",
   "description": "CLI app for linting package.json files.",
   "keywords": [
     "lint",

--- a/src/Config.js
+++ b/src/Config.js
@@ -23,7 +23,8 @@ class Config {
       'no-restricted-dependencies',
       'no-restricted-devDependencies',
       'no-restricted-pre-release-dependencies',
-      'no-restricted-pre-release-devDependencies'
+      'no-restricted-pre-release-devDependencies',
+      'prefer-property-order'
     ];
 
     this.passedConfigParam = passedConfigParam;

--- a/src/rules/prefer-property-order.js
+++ b/src/rules/prefer-property-order.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const isInPreferredOrder = require('./../validators/property-order').isInPreferredOrder;
+const LintIssue = require('./../LintIssue');
+const lintId = 'prefer-property-order';
+const nodeName = '';
+const message = 'Your package.json properties are not in the desired order.';
+const ruleType = 'property-order';
+
+const lint = function(packageJsonData, lintType, preferredOrder) {
+  const result = isInPreferredOrder(packageJsonData, preferredOrder);
+
+  if (!result.status) {
+    let helpTip = '';
+
+    if (result.data.actualNode === null) {
+      helpTip = `Please add ${result.data.desiredNode} at the end of the file.`;
+    } else {
+      helpTip = `Please move ${result.data.actualNode} after ${result.data.desiredNode}.`;
+    }
+
+    return new LintIssue(lintId, lintType, nodeName, `${message} ${helpTip}`);
+  }
+
+  return true;
+};
+
+module.exports.lint = lint;
+module.exports.ruleType = ruleType;

--- a/src/validators/alphabetical-sort.js
+++ b/src/validators/alphabetical-sort.js
@@ -27,7 +27,7 @@ const isInAlphabeticalOrder = function(packageJsonData, nodeName) {
   const nodeKeysOriginal = Object.keys(packageJsonData[nodeName]);
   const nodeKeysSorted = Object.keys(packageJsonData[nodeName]).sort();
 
-  for (let keyIndex = 0;keyIndex <= nodeKeysOriginal.length;keyIndex += increment) {
+  for (let keyIndex = 0;keyIndex < nodeKeysOriginal.length;keyIndex += increment) {
     if (nodeKeysOriginal[keyIndex] !== nodeKeysSorted[keyIndex]) {
       isValid = false;
       data = {

--- a/src/validators/property-order.js
+++ b/src/validators/property-order.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const increment = 1;
+
+/**
+ * Determines whether an array is in the specified order
+ * @param  {Object} packageJsonData     Valid JSON
+ * @param  {Array}  preferredNodeOrder  Preferred order of nodes
+ * @return {Object}                     Object containing the status and the node that is out of order, if applicable
+ */
+const isInPreferredOrder = function(packageJsonData, preferredNodeOrder) {
+  let isValid = true;
+  let data = {
+    actualNode: null,
+    desiredNode: null
+  };
+  const actualNodeList = Object.keys(packageJsonData);
+
+  for (let keyIndex = 0;keyIndex < preferredNodeOrder.length;keyIndex += increment) {
+    if (typeof actualNodeList[keyIndex] === 'undefined') {
+      isValid = false;
+      data = {
+        actualNode: null,
+        desiredNode: preferredNodeOrder[keyIndex]
+      };
+      break;
+    } else if (actualNodeList[keyIndex] !== preferredNodeOrder[keyIndex]) {
+      isValid = false;
+      data = {
+        actualNode: actualNodeList[keyIndex],
+        desiredNode: preferredNodeOrder[keyIndex]
+      };
+      break;
+    }
+  }
+
+  return {
+    status: isValid,
+    data
+  };
+};
+
+module.exports.isInPreferredOrder = isInPreferredOrder;

--- a/tests/unit/Config.test.js
+++ b/tests/unit/Config.test.js
@@ -387,7 +387,8 @@ describe('Config Unit Tests', function() {
           'require-version': 'warning',
           'valid-values-author': ['error', ['Thomas', 'Lindner', 'Thomas Lindner']],
           'valid-values-private': ['warning', [true, false]],
-          'valid-values-license': ['error', ['private', 'unlicensed']]
+          'valid-values-license': ['error', ['private', 'unlicensed']],
+          'prefer-property-order': ['error', ['name', 'version']]
         };
         const config = new Config(rcFileObj);
 

--- a/tests/unit/rules/prefer-property-order.test.js
+++ b/tests/unit/rules/prefer-property-order.test.js
@@ -19,7 +19,7 @@ describe('prefer-property-order Unit Tests', function() {
         'description'
       ];
       const response = lint(packageJsonData, 'error', preferredOrder);
-console.log(response);
+
       response.should.be.true;
     });
   });

--- a/tests/unit/rules/prefer-property-order.test.js
+++ b/tests/unit/rules/prefer-property-order.test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const chai = require('chai');
+const lint = require('./../../../src/rules/prefer-property-order').lint;
+
+const should = chai.should();
+
+describe('prefer-property-order Unit Tests', function() {
+  context('when the properties in the package.json file are in the desired order', function() {
+    it('true should be returned', function() {
+      const packageJsonData = {
+        name: 'awesome-module',
+        version: '1.0.0',
+        description: 'description'
+      };
+      const preferredOrder = [
+        'name',
+        'version',
+        'description'
+      ];
+      const response = lint(packageJsonData, 'error', preferredOrder);
+console.log(response);
+      response.should.be.true;
+    });
+  });
+
+  context('when the actual node list does not have the same number of nodes as the desired list', function() {
+    it('LintIssue object should be returned', function() {
+      const packageJsonData = {
+        name: 'awesome-module',
+        version: '1.0.0'
+      };
+      const preferredOrder = [
+        'name',
+        'version',
+        'description'
+      ];
+      const response = lint(packageJsonData, 'error', preferredOrder);
+
+      response.lintId.should.equal('prefer-property-order');
+      response.lintType.should.equal('error');
+      response.node.should.equal('');
+      response.lintMessage.should.equal('Your package.json properties are not in the desired order. Please add description at the end of the file.');
+    });
+  });
+
+  context('when the actual node list is in a different order than desired', function() {
+    it('LintIssue object should be returned', function() {
+      const packageJsonData = {
+        name: 'awesome-module',
+        description: 'description',
+        version: '1.0.0'
+      };
+      const preferredOrder = [
+        'name',
+        'version',
+        'description'
+      ];
+      const response = lint(packageJsonData, 'error', preferredOrder);
+
+      response.lintId.should.equal('prefer-property-order');
+      response.lintType.should.equal('error');
+      response.node.should.equal('');
+      response.lintMessage.should.equal('Your package.json properties are not in the desired order. Please move description after version.');
+    });
+  });
+});

--- a/tests/unit/validators/property-order.test.js
+++ b/tests/unit/validators/property-order.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const chai = require('chai');
+const propertyOrder = require('./../../../src/validators/property-order');
+
+const should = chai.should();
+
+describe('property-order Unit Tests', function() {
+  describe('isInPreferredOrder method', function() {
+    context('when the properties in the package.json file are in the desired order', function() {
+      it('true should be returned', function() {
+        const packageJson = {
+          name: 'awesome-module',
+          version: '1.0.0',
+          description: 'description'
+        };
+        const preferredOrder = [
+          'name',
+          'version',
+          'description'
+        ];
+        const response = propertyOrder.isInPreferredOrder(packageJson, preferredOrder);
+
+        response.status.should.be.true;
+        (response.data.actualNode === null).should.be.true;
+        (response.data.desiredNode === null).should.be.true;
+      });
+    });
+
+    context('when the actual node list does not have the same number of nodes as the desired list', function() {
+      it('false should be returned', function() {
+        const packageJson = {
+          name: 'awesome-module',
+          version: '1.0.0'
+        };
+        const preferredOrder = [
+          'name',
+          'version',
+          'description'
+        ];
+        const response = propertyOrder.isInPreferredOrder(packageJson, preferredOrder);
+
+        response.status.should.be.false;
+        (response.data.actualNode === null).should.be.true;
+        response.data.desiredNode.should.equal('description');
+      });
+    });
+
+    context('when the actual node list is in a different order than desired', function() {
+      it('false should be returned', function() {
+        const packageJson = {
+          name: 'awesome-module',
+          description: 'description',
+          version: '1.0.0'
+        };
+        const preferredOrder = [
+          'name',
+          'version',
+          'description'
+        ];
+        const response = propertyOrder.isInPreferredOrder(packageJson, preferredOrder);
+
+        response.status.should.be.false;
+        response.data.actualNode.should.equal('description');
+        response.data.desiredNode.should.equal('version');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Add a new rule, prefer-property-order, that allows users to specify an
array of properties in the order they desire.

Fixed a bug that caused alphabetical-sort to quietly go out of bounds