### PR TITLE
Fix error message when property should be before other

### DIFF
--- a/src/validators/property-order.js
+++ b/src/validators/property-order.js
@@ -78,7 +78,11 @@ const isInPreferredOrder = function(packageJsonData, userPreferredNodeOrder) {
 
     const preferredOrderPosition = filteredPreferredOrderMap.get(currentPkgJsonProperty);
 
-    if (preferredOrderPosition !== keyIndex) {
+    if (preferredOrderPosition > keyIndex) {
+      isValid = false;
+      msg = `Please move "${fltrdPreferredNodeOrder[preferredOrderPosition - one]}" before "${currentPkgJsonProperty}".`;
+      break;
+    } else if (preferredOrderPosition < keyIndex) {
       isValid = false;
       msg = `Please move "${currentPkgJsonProperty}" after "${fltrdPreferredNodeOrder[preferredOrderPosition - one]}".`;
       break;


### PR DESCRIPTION
** Description of change **
Regarding issue #58. Fix error message when a property should be before other one.

** Checklist **

  - [ ] Unit tests have been added
  - [ ] Specific notes for documentation, if applicable
