### PR TITLE
Add rule for repository.directory field

### DIFF
--- a/src/rules/require-repository-directory.js
+++ b/src/rules/require-repository-directory.js
@@ -1,0 +1,17 @@
+const LintIssue = require('./../LintIssue');
+
+const lintId = 'require-repository-directory';
+const nodeName = 'repository';
+const message = 'repository object missing directory property';
+const ruleType = 'standard';
+
+const lint = (packageJsonData, severity) => {
+  if (!packageJsonData[nodeName].hasOwnProperty('directory')) {
+    return new LintIssue(lintId, severity, nodeName, message);
+  }
+
+  return true;
+};
+
+module.exports.lint = lint;
+module.exports.ruleType = ruleType;

--- a/src/rules/require-repository-directory.js
+++ b/src/rules/require-repository-directory.js
@@ -2,10 +2,15 @@ const LintIssue = require('./../LintIssue');
 
 const lintId = 'require-repository-directory';
 const nodeName = 'repository';
+const parentNodeMessage = 'repository is required';
 const message = 'repository object missing directory property';
 const ruleType = 'standard';
 
 const lint = (packageJsonData, severity) => {
+  if (!packageJsonData.hasOwnProperty(nodeName)) {
+    return new LintIssue(lintId, severity, nodeName, parentNodeMessage);
+  }
+
   if (!packageJsonData[nodeName].hasOwnProperty('directory')) {
     return new LintIssue(lintId, severity, nodeName, message);
   }

--- a/test/unit/rules/require-repository-directory.test.js
+++ b/test/unit/rules/require-repository-directory.test.js
@@ -9,6 +9,18 @@ describe('require-repository-directory Unit Tests', () => {
     });
   });
 
+  describe('when package.json does not have parent node', () => {
+    test('false should be returned', () => {
+      const packageJsonData = {};
+      const response = lint(packageJsonData, 'error');
+
+      expect(response.lintId).toStrictEqual('require-repository-directory');
+      expect(response.severity).toStrictEqual('error');
+      expect(response.node).toStrictEqual('repository');
+      expect(response.lintMessage).toStrictEqual('repository is required');
+    });
+  });
+
   describe('when package.json has node', () => {
     test('true should be returned', () => {
       const packageJsonData = {

--- a/test/unit/rules/require-repository-directory.test.js
+++ b/test/unit/rules/require-repository-directory.test.js
@@ -1,0 +1,41 @@
+const ruleModule = require('./../../../src/rules/require-repository-directory');
+
+const {lint, ruleType} = ruleModule;
+
+describe('require-repository-directory Unit Tests', () => {
+  describe('a rule type value should be exported', () => {
+    test('it should equal "standard"', () => {
+      expect(ruleType).toStrictEqual('standard');
+    });
+  });
+
+  describe('when package.json has node', () => {
+    test('true should be returned', () => {
+      const packageJsonData = {
+        repository: {
+          url: 'https://github.com/packages/monorepo',
+          directory: 'packages/somepackage'
+        }
+      };
+      const response = lint(packageJsonData, 'error');
+
+      expect(response).toBeTruthy();
+    });
+  });
+
+  describe('when package.json does not have node', () => {
+    test('LintIssue object should be returned', () => {
+      const packageJsonData = {
+        repository: {
+          url: 'https://github.com/packages/monorepo'
+        }
+      };
+      const response = lint(packageJsonData, 'error');
+
+      expect(response.lintId).toStrictEqual('require-repository-directory');
+      expect(response.severity).toStrictEqual('error');
+      expect(response.node).toStrictEqual('repository');
+      expect(response.lintMessage).toStrictEqual('repository object missing directory property');
+    });
+  });
+});


### PR DESCRIPTION
**Description of change**

This PR adds a rule which can be used to enforce the presence of a repository.directory field, as per:

- https://github.com/npm/rfcs/blob/latest/implemented/0010-monorepo-subdirectory-declaration.md.
- https://github.com/npm/cli/releases/tag/v6.8.0

**Checklist**

  - [x] Unit tests have been added
  - [ ] Specific notes for documentation, if applicable
