### PR TITLE
fix: require.resolve in Node 12.3.0 needs an array for paths option

### DIFF
--- a/src/config/ConfigFile.js
+++ b/src/config/ConfigFile.js
@@ -61,7 +61,7 @@ const loadFromModule = (moduleName, configContext, originalFilePath) => {
     adjustedModuleName = path.join(configContext.options.cwd, moduleName);
     config = loadConfigFile(adjustedModuleName);
   } else {
-    const resolvedModule = require.resolve(adjustedModuleName, {paths: path.dirname(originalFilePath)});
+    const resolvedModule = require.resolve(adjustedModuleName, {paths: [path.dirname(originalFilePath)]});
 
     config = require(resolvedModule);
   }


### PR DESCRIPTION
The documentation for `require.resolve` indicates that the `paths` option must be an array. That's been the case at least as far back as Node 8, which is the oldest version of Node still supported as we speak. `npm-package-json-lint` passed a single string, which *happened* to work.

12.3.0 introduced a change that causes a single string to no longer work.

See https://github.com/nodejs/node/issues/27827

This PR fixes that problem. Without the PR, `npm-package-json-lint` crashes when I run it on a project that uses `extends` in its configuration.