### PR TITLE
New rule: no duplicate fields

### DIFF
--- a/docs/rules/dependencies/no-dup-fields.md
+++ b/docs/rules/dependencies/no-dup-fields.md
@@ -1,0 +1,63 @@
+---
+id: no-dup-fields
+title: no-dup-fields
+---
+
+Enabling this rule will result in an error being generated if package.json has duplicate fields in block section.
+
+## Example .npmpackagejsonlintrc configuration
+
+```json
+{
+  "rules": {
+    "no-dup-fields": "error"
+  }
+}
+```
+
+With exceptions
+
+```json
+{
+  "rules": {
+    "no-dup-fields": ["error", {
+      "exceptions": ["myModule"]
+    }]
+  }
+}
+```
+
+## Rule Details
+
+### *Incorrect* examples
+
+```json
+{
+  "name": "packageName",
+  "name": "packageName"
+}
+```
+
+
+### *Correct* examples
+
+
+```json
+{
+  "name": "packageName"
+}
+```
+
+## Shorthand for disabling the rule in .npmpackagejsonlintrc configuration
+
+```json
+{
+  "rules": {
+    "no-dup-fields": "off"
+  }
+}
+```
+
+## History
+
+* Introduced in version 4.3.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -5315,6 +5315,11 @@
         }
       }
     },
+    "jsonc-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.0.tgz",
+      "integrity": "sha512-4fLQxW1j/5fWj6p78vAlAafoCKtuBm6ghv+Ij5W2DrDx0qE+ZdEl2c6Ko1mgJNF5ftX1iEWQQ4Ap7+3GlhjkOA=="
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "globby": "^10.0.1",
     "ignore": "^5.1.4",
     "is-plain-obj": "^2.0.0",
+    "jsonc-parser": "^2.2.0",
     "log-symbols": "^3.0.0",
     "meow": "^5.0.0",
     "plur": "^3.1.1",

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -47,14 +47,22 @@ class Parser {
    */
   static parseJsonFile(fileName) {
     let json = {};
+    let fileContents = '';
 
     try {
-      const fileContents = readFile(fileName);
+      fileContents = readFile(fileName);
 
       json = JSON.parse(stripComments(fileContents));
     } catch (err) {
       handleError(fileName, err);
     }
+
+    Object.defineProperty(json, Parser.sourceSymbol, {
+      value: fileContents,
+      enumerable: false,
+      writable: false,
+      configurable: false
+    });
 
     return json;
   }
@@ -78,5 +86,7 @@ class Parser {
     return obj;
   }
 }
+
+Parser.sourceSymbol = Symbol('JSON source');
 
 module.exports = Parser;

--- a/src/rules/no-dup-fields.js
+++ b/src/rules/no-dup-fields.js
@@ -1,0 +1,29 @@
+const Parser = require('../Parser');
+const {findDuplicatePropNames} = require('../validators/property');
+const LintIssue = require('./../LintIssue');
+
+const lintId = 'no-duplicate-fields';
+const nodeName = '';
+const ruleType = 'optionalObject';
+
+const lint = (packageJsonData, severity) => {
+  /**
+   * If we send package json straight to npm-package-json-lint, fallback to empty string.
+   * Because we already lose information about duplicate properties.
+   */
+  const source = packageJsonData[Parser.sourceSymbol] || ''; // eslint-disable-line
+  const dupProps = findDuplicatePropNames(source);
+
+  if (dupProps.length) {
+    const message = `You have duplicate field names: ${dupProps.join(', ')}. Please remove duplicates.`;
+
+    return new LintIssue(lintId, severity, nodeName, message);
+  }
+
+  return true;
+};
+
+module.exports = {
+  lint,
+  ruleType
+};

--- a/src/validators/property.js
+++ b/src/validators/property.js
@@ -8,6 +8,45 @@ const exists = (packageJsonData, nodeName) => {
   return packageJsonData.hasOwnProperty(nodeName);
 };
 
+/**
+ * Search for duplicate properties in package.json file
+ * @param  {string}  packageJsonSource JSON source string
+ * @return {string[]}                  List of duplicate property names.
+ */
+const findDuplicatePropNames = packageJsonSource => {
+  const parser = require("jsonc-parser"); // eslint-disable-line
+  const tree = parser.parseTree(packageJsonSource);
+
+  if (!tree) {
+    return [];
+  }
+
+  const traverse = (node, dups = []) => {
+    const foundProps = new Map();
+
+    // eslint-disable-next-line
+    for (const child of node.children) {
+      const [propNameNode, propValNode] = child.children;
+      const propName = propNameNode.value;
+
+      if (foundProps.has(propName)) {
+        dups.push(propName);
+      } else {
+        foundProps.set(propName, true);
+      }
+
+      if (propValNode.type === 'object') {
+        traverse(propValNode, dups);
+      }
+    }
+
+    return dups;
+  };
+
+  return traverse(tree);
+};
+
 module.exports = {
-  exists
+  exists,
+  findDuplicatePropNames
 };

--- a/test/unit/Parser.test.js
+++ b/test/unit/Parser.test.js
@@ -13,7 +13,9 @@ describe('Parser Unit Tests', () => {
         };
         fs.readFileSync.mockReturnValue(json);
 
-        expect(Parser.parseJsonFile('dummyFile.txt')).toStrictEqual(obj);
+        const parsedJson = Parser.parseJsonFile('dummyFile.txt');
+        expect(parsedJson).toStrictEqual(obj);
+        expect(parsedJson[Parser.sourceSymbol]).toStrictEqual(json);
       });
     });
 

--- a/test/unit/rules/no-dup-fields.test.js
+++ b/test/unit/rules/no-dup-fields.test.js
@@ -1,0 +1,63 @@
+const ruleModule = require('./../../../src/rules/no-dup-fields');
+const Parser = require('../../../src/Parser');
+
+const {lint, ruleType} = ruleModule;
+
+const parsePackageJson = source => {
+  const json = JSON.parse(source);
+  json[Parser.sourceSymbol] = source; // eslint-disable-line
+
+  return json;
+};
+
+describe('no-dup-fields Unit Tests', () => {
+  describe('a rule type value should be exported', () => {
+    test('it should equal "optionalObject"', () => {
+      expect(ruleType).toStrictEqual('optionalObject');
+    });
+  });
+
+  describe('when package.json has duplicate fields', () => {
+    test('LintIssue object should be returned', () => {
+      const packageJsonData = parsePackageJson(`{
+        "name": "package1",
+        "name": "package2"
+      }`);
+      const response = lint(packageJsonData, 'error', {exceptions: ['grunt-npm-package-json-lint']});
+
+      expect(response.lintId).toStrictEqual('no-duplicate-fields');
+      expect(response.severity).toStrictEqual('error');
+      expect(response.lintMessage).toStrictEqual('You have duplicate field names: name. Please remove duplicates.');
+    });
+  });
+
+  describe('when package.json has nested duplicate fields', () => {
+    test('LintIssue object should be returned', () => {
+      const packageJsonData = parsePackageJson(`{
+        "name": "package",
+        "devDependencies": {
+          "eslint": "6.7.2",
+          "eslint-config-tc": "9.0.0",
+          "eslint": "6.7.2"
+        }
+      }`);
+      const response = lint(packageJsonData, 'error', {exceptions: ['grunt-npm-package-json-lint']});
+
+      expect(response.lintId).toStrictEqual('no-duplicate-fields');
+      expect(response.severity).toStrictEqual('error');
+      expect(response.lintMessage).toStrictEqual('You have duplicate field names: eslint. Please remove duplicates.');
+    });
+  });
+
+  describe('when package.json without duplicates', () => {
+    test('true should be returned', () => {
+      const packageJsonData = parsePackageJson(`{
+        "name": "package1",
+        "version": "0.1.0"
+      }`);
+      const response = lint(packageJsonData, 'error');
+
+      expect(response).toBe(true);
+    });
+  });
+});

--- a/test/unit/validators/property.test.js
+++ b/test/unit/validators/property.test.js
@@ -24,4 +24,35 @@ describe('property Unit Tests', () => {
       });
     });
   });
+  describe('findDuplicatePropNames method', () => {
+    describe('when duplicates properties exists', () => {
+      test('list with names should be returnd', () => {
+        const packageJsonSource = `{
+          "version": "1.0.0",
+          "name": "package",
+          "version": "1.0.0",
+          "scripts": {
+            "test": "jest",
+            "test:ci": "jest --runInBand",
+            "test:ci": "jest --runInBand"
+          }
+        }`;
+        const response = property.findDuplicatePropNames(packageJsonSource);
+
+        expect(response).toStrictEqual(expect.arrayContaining(['version', 'test:ci']));
+      });
+    });
+
+    describe('when duplicates properties does not exists', () => {
+      test('empty list should be returned', () => {
+        const packageJsonSource = `{
+          "name": "package",
+          "version": "1.0.0"
+        }`;
+        const response = property.findDuplicatePropNames(packageJsonSource);
+
+        expect(response).toHaveLength(0);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Disallow duplicate properties in `package.json`. Realted to #171.

Detection algorithm:

* Save source `json` string.
* Parse source via `jsonc-parser`.
* Traverse parse tree and collect duplicates.

**Checklist**

  - [x] Unit tests have been added
  - [x] Specific notes for documentation, if applicable
