### PR TITLE
fix removing negation of option validation

### DIFF
--- a/src/NpmPackageJsonLint.js
+++ b/src/NpmPackageJsonLint.js
@@ -27,7 +27,7 @@ const isPackageJsonObjectValid = (packageJsonObject) => isPlainObj(packageJsonOb
 
 const areRequiredOptionsValid = (packageJsonObject, patterns) => {
   return (
-    (!patterns && !isPackageJsonObjectValid(packageJsonObject)) ||
+    (!patterns && isPackageJsonObjectValid(packageJsonObject)) ||
     (patterns && (packageJsonObject || isPackageJsonObjectValid(packageJsonObject)))
   );
 };


### PR DESCRIPTION
Haii, i found a bug with a seemingly simple fix. let me know if i was mistaken


* A little info about your environment
  * npm-package-json-lint version
    * 5.1.0
  * npm version
      * pnpm version 4.12.1
  * node version
      * v14.2.0
  * The output from npm-package-json-lint
I receive an error telling me i have to pass either `patterns` or `packageJsonObject`. But I am doing exactly that...
```txt
Error: You must pass npm-package-json-lint a `patterns` glob or a `packageJsonObject` string, though not both.
    at NpmPackageJsonLint.lint (/home/edwin/docs/programming/projects/fox-suite/fox-lint-package-json/node_modules/.pnpm/registry.npmjs.org/npm-package-json-lint/5.1.0/node_modules/npm-package-json-lint/src/NpmPackageJsonLint.js:120:13)
    at lintPackageJson (/home/edwin/docs/programming/projects/fox-suite/fox-lint-package-json/src/index.ts:21:44)
    at /home/edwin/docs/programming/projects/fox-suite/fox-lint-package-json/src/index.ts:25:14
```
* What you expected to happen
I expected the output to report the stats (this is the `console.log(output)` text in the code below)
```txt
{
  results: [
    {
      filePath: './package.json',
      issues: [Array],
      ignored: false,
      errorCount: 7,
      warningCount: 0
    }
  ],
  ignoreCount: 0,
  errorCount: 7,
  warningCount: 0
}
```
* The steps to reproduce the problem
This code reproduces the problem
```js
// index.js
import { NpmPackageJsonLint } from 'npm-package-json-lint'

async function lintPackageJson() {
  const packageJson = await fs.promises.readFile('./package.json', { encoding: 'utf8' })
  const lintPackageJsonConfig = JSON.parse(await fs.promises.readFile('./.npmpackagejsonlintrc.json', { encoding: 'utf8' }))

  const npmPackageLint = new NpmPackageJsonLint({
    cwd: process.cwd(),
    packageJsonObject: packageJson,
    packageJsonFilePath: './packageee.json',
    config: lintPackageJsonConfig,
    // configFile: '',
    // patterns: ['**/package.json'],
    quiet: false,
    // ignorePath: ''
  })

  const output = npmPackageLint.lint()
  console.log(output)
}

(async () => await lintPackageJson())()
```

**Description of change**
This pr removes the negation of the `isPackageJsonObjectValid(packageJsonObject)` call in the `areRequiredOptionsValid` function. It seemed that was the intended behavior as if patterns is specified, we can still continue if and only if the `packageJsonObject` is valid.

This change causes program behavior to align with the "what you expected to happen" section in this pr

**Checklist**

  - [] Unit tests have been added
  - [] Specific notes for documentation, if applicable

I did not add any unit tests or documentation. If I should (for this very minor change) please me know :)