### PR TITLE
Experimental eslint integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "chalk": "^4.1.0",
     "cosmiconfig": "^6.0.0",
     "debug": "^4.3.1",
+    "eslint-plugin-package-json": "file:./src/eslint",
     "globby": "^11.0.2",
     "ignore": "^5.1.8",
     "is-plain-obj": "^3.0.0",

--- a/src/eslint/index.js
+++ b/src/eslint/index.js
@@ -1,0 +1,5 @@
+const rule = require('./rule');
+
+module.exports.rules = {
+  'package-json': rule,
+};

--- a/src/eslint/package.json
+++ b/src/eslint/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "eslint-plugin-package-json",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "dependencies": {
+    "npm-package-json-lint": "file:../../"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/src/eslint/parser.js
+++ b/src/eslint/parser.js
@@ -1,0 +1,21 @@
+module.exports = {
+  parseForESLint(code, {filePath}) {
+    // We don't have JS, so this AST is for empty JS file
+    return {
+      ast: {
+        type: 'Program',
+        start: 0,
+        end: 0,
+        loc: {start: {line: 1, column: 0}, end: {line: 1, column: 0}},
+        range: [0, 0],
+        body: [],
+        tokens: [],
+        comments: [],
+      },
+      services: {
+        getPackageJson: () => code,
+        getPath: () => filePath,
+      },
+    };
+  },
+};

--- a/src/eslint/rule.js
+++ b/src/eslint/rule.js
@@ -1,0 +1,41 @@
+const {NpmPackageJsonLint} = require('npm-package-json-lint');
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          rules: {
+            type: 'object',
+            additionalProperties: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context) {
+    return {
+      Program(node) {
+        const linter = new NpmPackageJsonLint({
+          packageJsonObject: JSON.parse(context.parserServices.getPackageJson()),
+          packageJsonFilePath: context.parserServices.getPath(),
+          config: context.options[0],
+        });
+        const results = linter.lint();
+
+        if (results.results.length > 0) {
+          results.results[0].issues.forEach(({lintMessage, lintId}) => {
+            context.report({
+              node,
+              message: `(${lintId}) ${lintMessage}`,
+            });
+          });
+        }
+      },
+    };
+  },
+};

--- a/test/integration/eslint/.eslintrc.js
+++ b/test/integration/eslint/.eslintrc.js
@@ -1,0 +1,19 @@
+module.exports = {
+  root: true,
+  overrides: [
+    {
+      plugins: ['package-json'],
+      files: ['**/package.json'],
+      parser: '../../../src/eslint/parser.js',
+      rules: {
+        'package-json/package-json': ['error', {
+          rules: {
+            'require-name': 'error',
+            'require-version': 'error',
+            'prefer-alphabetical-scripts': 'error',
+          }
+        }],
+      },
+    },
+  ],
+};

--- a/test/integration/eslint/example1/package.json
+++ b/test/integration/eslint/example1/package.json
@@ -1,0 +1,10 @@
+{
+  "main": "index.js",
+  "scripts": {
+    "build": "build script",
+    "test": "jest",
+    "start": "node index.js"
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
EXPERIMENT FOR #323 - NOT TO MERGE

**Description of change**

This is a proof of concept on how this tool can integrate with ESlint.

**How it works**

- Define a parser for ESLint. This parser is used to parse `package.json` files. It works by returning an empty AST tree to ESLint (so eslint pretty much ignores it) but also providing "parser services" that rules can use. Those services are used to expose the content of `package.json` and its path
- Define a new package `eslint-plugin-package-json` that is an [ESlint plugin](https://eslint.org/docs/developer-guide/working-with-plugins). AFAIK this _has_ to be a package prefixed with `eslint-plugin`.
- This package defines a single rule called `package-json`. This rule uses the "parser services" to load the content of `package.json`, calls `npm-package-json-lint` API to lint it, and re-shapes the error report in the format that eslint expects.


**Caveats**

- The way ESLint rules (or parser) work is file by file. It means that options like rule overrides won't work. Instead, the user should rely on ESLint's override system to implement the same logic.
- ESLint really wants to have plugins as isolated packages with a specific name. Given that implementing ESLint support doesn't really change any in the core of `npm-package-json-lint`, this may be best implemented as a separate package.

Please let me know what you think. I'm happy to implement this "for good" in this package, or create a separate package for it.