### PR TITLE
Add type definitions.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,52 @@
+interface LintIssue {
+    lintId: string;
+    severity: 'error' | 'warning';
+    node: 'string';
+    lintMessage: 'string';
+}
+
+interface FileLintResult {
+    filePath: string;
+    issues: LintIssue[];
+    ignored: boolean;
+    errorCount: number;
+    warningCount: number;
+}
+
+interface LinterResult {
+    results: FileLintResult[];
+    ignoreCount: number;
+    errorCount: number;
+    warningCount: number;
+}
+
+type NpmPackageJsonLintOptions = {
+    cwd?: string;
+    config?: object;
+    configFile: string;
+    configBaseDirectory?: string;
+    quiet?: boolean;
+    ignorePath?: string;
+    fix?: boolean;
+} & (
+  {
+    packageJsonObject: object,
+    packageJsonFilePath?: string;
+  } |
+  {
+    patterns: string[]
+  }
+);
+
+declare class NpmPackageJsonLint {
+    constructor (options: NpmPackageJsonLintOptions);
+
+    lint(): LinterResult;
+}
+
+export {
+    FileLintResult,
+    LinterResult,
+    LintIssue,
+    NpmPackageJsonLint
+};

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "CONTRIBUTING.md"
   ],
   "main": "src/api.js",
+  "types": "index.d.ts",
   "scripts": {
     "eslint": "eslint . --format=node_modules/eslint-formatter-pretty",
     "npmpackagejsonlint": "node src/cli.js ./package.json",


### PR DESCRIPTION
**Description of change**

Hi :wave: 

I want to use this cool tool in a TypeScript project I am working on. Since the linter is written in JavaScript and has no type definitions, I thought I'd contribute some TypeScript types. They should cover the entire public-facing API.

Please tell me if I misunderstood some parameters or if you'd rather move the `index.d.ts` file to a different location.

**Checklist**

  - [ ] Unit tests have been added
  - [ ] Specific notes for documentation, if applicable
