### PR TITLE
fix: Add index.d.ts to package files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "files": [
     "src",
-    "CONTRIBUTING.md"
+    "CONTRIBUTING.md",
+    "index.d.ts"
   ],
   "main": "src/api.js",
   "types": "index.d.ts",


### PR DESCRIPTION
**Description of change**

Hi, another PR from me. I missed that you use the `files` field in the `package.json` file to list the files contained in the npm package, and thus did not include the `index.d.ts` file. It's currently missing from the npm package.

This PR adds it :)

**Checklist**

  - [ ] Unit tests have been added
  - [ ] Specific notes for documentation, if applicable
