### PR TITLE
fix: documentation links to past versions

### DIFF
--- a/website/pages/en/versions.js
+++ b/website/pages/en/versions.js
@@ -82,7 +82,7 @@ function Versions(props) {
                         <a
                           href={`${siteConfig.baseUrl}${siteConfig.docsUrl}/${
                             props.language ? props.language + '/' : ''
-                          }${version}/doc1`}>
+                          }${version}/`}>
                           Documentation
                         </a>
                       </td>


### PR DESCRIPTION
**Description of change**
The links to past versions documentations lead to a 404, compare to https://npmpackagejsonlint.org/en/versions

It's mainly a `doc1` which is added to the URL that probably shouldn't belong there.