### PR TITLE
Fix `no-git-dependencies` rule

### DIFF
--- a/src/validators/dependency-audit.js
+++ b/src/validators/dependency-audit.js
@@ -242,7 +242,7 @@ const isGithubRepositoryShortcut = (version) => {
  * @return {boolean}    True if the version is url to archive
  */
 const isArchiveUrl = (version) => {
-  return version.endsWith('.tar.gz') || version.endsWith('.zip');
+  return version.endsWith('.tgz') || version.endsWith('.tar.gz') || version.endsWith('.zip');
 };
 
 /**

--- a/test/unit/rules/no-git-dependencies.test.js
+++ b/test/unit/rules/no-git-dependencies.test.js
@@ -234,4 +234,18 @@ describe('no-git-dependencies Unit Tests', () => {
       expect(response).toBe(true);
     });
   });
+
+  describe('when package.json has node with an archive URL', () => {
+    test('true should be returned', () => {
+      const packageJsonData = {
+        dependencies: {
+          'my-module-v3':
+            'https://registry.npmjs.org/npm-package-json-lint-config-default/-/npm-package-json-lint-config-default-3.0.0.tgz',
+        },
+      };
+      const response = lint(packageJsonData, 'error');
+
+      expect(response).toBe(true);
+    });
+  });
 });

--- a/test/unit/rules/no-git-devDependencies.test.js
+++ b/test/unit/rules/no-git-devDependencies.test.js
@@ -234,4 +234,18 @@ describe('no-git-devDependencies Unit Tests', () => {
       expect(response).toBe(true);
     });
   });
+
+  describe('when package.json has node with an archive URL', () => {
+    test('true should be returned', () => {
+      const packageJsonData = {
+        devDependencies: {
+          'my-module-v3':
+            'https://registry.npmjs.org/npm-package-json-lint-config-default/-/npm-package-json-lint-config-default-3.0.0.tgz',
+        },
+      };
+      const response = lint(packageJsonData, 'error');
+
+      expect(response).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
**Description of change**
The `no-git-dependencies` rule incorrectly identifies an archive URL as a git URL.

Added the `.tgz` common archive format to the `isArchiveUrl` function.
This fixes both the `no-git-dependencies` and `no-git-devDependencies`
rules.



**Checklist**

  - [x] Unit tests have been added
  - [ ] Specific notes for documentation, if applicable
