### PR TITLE
Include current config and valid values in output when an issue is detected

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint": "eslint . --format=node_modules/eslint-formatter-pretty",
     "npmpackagejsonlint": "node dist/cli.js ./package.json",
     "lint": "npm run eslint && npm run npmpackagejsonlint",
-    "test": "jest",
+    "test": "npm run build && jest",
     "test:ci": "jest --runInBand",
     "tsc": "tsc --project tsconfig.json"
   },

--- a/src/rules/valid-values-author.ts
+++ b/src/rules/valid-values-author.ts
@@ -36,7 +36,12 @@ export const lint = <T>(
   }
 
   if (!isValidValue<T>(packageJsonData, nodeName, value, validValues)) {
-    return new LintIssue(lintId, severity, nodeName, `Invalid value for author. Current value is ${value}. Value values include: ${validValues.join(', ')}.`);
+    return new LintIssue(
+      lintId,
+      severity,
+      nodeName,
+      `Invalid value for author. Current value is ${value}. Value values include: ${validValues.join(', ')}.`
+    );
   }
 
   return null;

--- a/src/rules/valid-values-author.ts
+++ b/src/rules/valid-values-author.ts
@@ -8,7 +8,6 @@ import {isValidValue} from '../validators/valid-values';
 
 const lintId = 'valid-values-author';
 const nodeName = 'author';
-const message = 'Invalid value for author';
 
 export const ruleType = RuleType.Array;
 
@@ -37,7 +36,7 @@ export const lint = <T>(
   }
 
   if (!isValidValue<T>(packageJsonData, nodeName, value, validValues)) {
-    return new LintIssue(lintId, severity, nodeName, message);
+    return new LintIssue(lintId, severity, nodeName, `Invalid value for author. Current value is ${value}. Value values include: ${validValues.join(', ')}.`);
   }
 
   return null;

--- a/src/rules/valid-values-engines.ts
+++ b/src/rules/valid-values-engines.ts
@@ -26,7 +26,14 @@ export const lint = (
       const valueAsJsonString = JSON.stringify(packageJsonData[nodeName]);
 
       if (!isValidValue<string>(packageJsonData, nodeName, valueAsJsonString, validValuesAsJsonString)) {
-        return new LintIssue(lintId, severity, nodeName, `Invalid value for engines. Current value is ${valueAsJsonString}. Value values include: ${validValuesAsJsonString.join(', ')}.`);
+        return new LintIssue(
+          lintId,
+          severity,
+          nodeName,
+          `Invalid value for engines. Current value is ${valueAsJsonString}. Value values include: ${validValuesAsJsonString.join(
+            ', '
+          )}.`
+        );
       }
 
       // eslint-disable-next-line no-restricted-syntax, guard-for-in

--- a/src/rules/valid-values-engines.ts
+++ b/src/rules/valid-values-engines.ts
@@ -9,7 +9,6 @@ import {isValidValue} from '../validators/valid-values';
 
 const lintId = 'valid-values-engines';
 const nodeName = 'engines';
-const message = 'Invalid value for engines';
 
 export const ruleType = RuleType.Array;
 
@@ -27,7 +26,7 @@ export const lint = (
       const valueAsJsonString = JSON.stringify(packageJsonData[nodeName]);
 
       if (!isValidValue<string>(packageJsonData, nodeName, valueAsJsonString, validValuesAsJsonString)) {
-        return new LintIssue(lintId, severity, nodeName, message);
+        return new LintIssue(lintId, severity, nodeName, `Invalid value for engines. Current value is ${valueAsJsonString}. Value values include: ${validValuesAsJsonString.join(', ')}.`);
       }
 
       // eslint-disable-next-line no-restricted-syntax, guard-for-in

--- a/src/rules/valid-values-license.ts
+++ b/src/rules/valid-values-license.ts
@@ -6,7 +6,6 @@ import {isValidValue} from '../validators/valid-values';
 
 const lintId = 'valid-values-license';
 const nodeName = 'license';
-const message = 'Invalid value for license';
 
 export const ruleType = RuleType.Array;
 
@@ -27,7 +26,14 @@ export const lint = (
   validValues: string[]
 ): LintIssue | null => {
   if (!isValidValue<string>(packageJsonData, nodeName, packageJsonData[nodeName], validValues)) {
-    return new LintIssue(lintId, severity, nodeName, message);
+    return new LintIssue(
+      lintId,
+      severity,
+      nodeName,
+      `Invalid value for license. Current value is ${packageJsonData[nodeName]}. Valid values include: ${validValues.join(
+        ', '
+      )}.`
+    );
   }
 
   return null;

--- a/src/rules/valid-values-name-scope.ts
+++ b/src/rules/valid-values-name-scope.ts
@@ -29,7 +29,14 @@ export const lint = (
   const validRegexes = validValues.map((scope) => new RegExp(`^${scope}/`));
 
   if (!matchValidValue(packageJsonData, nodeName, packageJsonData[nodeName], validRegexes)) {
-    return new LintIssue(lintId, severity, nodeName, `Invalid value for name scope. Current value is ${packageJsonData[nodeName]}. Valid values include: ${validValues.join(', ')}.`);
+    return new LintIssue(
+      lintId,
+      severity,
+      nodeName,
+      `Invalid value for name scope. Current value is ${
+        packageJsonData[nodeName]
+      }. Valid values include: ${validValues.join(', ')}.`
+    );
   }
 
   return null;

--- a/src/rules/valid-values-name-scope.ts
+++ b/src/rules/valid-values-name-scope.ts
@@ -7,7 +7,6 @@ import {matchValidValue} from '../validators/valid-values';
 
 const lintId = 'valid-values-name-scope';
 const nodeName = 'name';
-const message = 'Invalid value for name scope';
 
 export const ruleType = RuleType.Array;
 
@@ -30,7 +29,7 @@ export const lint = (
   const validRegexes = validValues.map((scope) => new RegExp(`^${scope}/`));
 
   if (!matchValidValue(packageJsonData, nodeName, packageJsonData[nodeName], validRegexes)) {
-    return new LintIssue(lintId, severity, nodeName, message);
+    return new LintIssue(lintId, severity, nodeName, `Invalid value for name scope. Current value is ${packageJsonData[nodeName]}. Valid values include: ${validValues.join(', ')}.`);
   }
 
   return null;

--- a/src/rules/valid-values-private.ts
+++ b/src/rules/valid-values-private.ts
@@ -7,7 +7,6 @@ import {isValidValue} from '../validators/valid-values';
 
 const lintId = 'valid-values-private';
 const nodeName = 'private';
-const message = 'Invalid value for private';
 
 export const ruleType = RuleType.Array;
 
@@ -27,7 +26,14 @@ export const lint = (
   validValues: boolean[]
 ): LintResult => {
   if (!isValidValue<boolean>(packageJsonData, nodeName, packageJsonData[nodeName], validValues)) {
-    return new LintIssue(lintId, severity, nodeName, message);
+    return new LintIssue(
+      lintId,
+      severity,
+      nodeName,
+      `Invalid value for private. Current value is ${packageJsonData[nodeName]}. Valid values include: ${validValues.join(
+        ', '
+      )}.`
+    );
   }
 
   return null;

--- a/src/rules/valid-values-publishConfig.ts
+++ b/src/rules/valid-values-publishConfig.ts
@@ -25,7 +25,14 @@ export const lint = (
       const valueAsJsonString = JSON.stringify(packageJsonData[nodeName]);
 
       if (!isValidValue<string>(packageJsonData, nodeName, valueAsJsonString, validValuesAsJsonString)) {
-        return new LintIssue(lintId, severity, nodeName, `Invalid value for publishConfig. Current value is ${valueAsJsonString}. Value values include: ${validValuesAsJsonString.join(', ')}.`);
+        return new LintIssue(
+          lintId,
+          severity,
+          nodeName,
+          `Invalid value for publishConfig. Current value is ${valueAsJsonString}. Value values include: ${validValuesAsJsonString.join(
+            ', '
+          )}.`
+        );
       }
     } else {
       return new LintIssue(lintId, severity, nodeName, 'publishConfig node has invalid data type');

--- a/src/rules/valid-values-publishConfig.ts
+++ b/src/rules/valid-values-publishConfig.ts
@@ -8,7 +8,6 @@ import {isValidValue} from '../validators/valid-values';
 
 const lintId = 'valid-values-publishConfig';
 const nodeName = 'publishConfig';
-const message = 'Invalid value for publishConfig';
 
 export const ruleType = RuleType.Array;
 
@@ -26,7 +25,7 @@ export const lint = (
       const valueAsJsonString = JSON.stringify(packageJsonData[nodeName]);
 
       if (!isValidValue<string>(packageJsonData, nodeName, valueAsJsonString, validValuesAsJsonString)) {
-        return new LintIssue(lintId, severity, nodeName, message);
+        return new LintIssue(lintId, severity, nodeName, `Invalid value for publishConfig. Current value is ${valueAsJsonString}. Value values include: ${validValuesAsJsonString.join(', ')}.`);
       }
     } else {
       return new LintIssue(lintId, severity, nodeName, 'publishConfig node has invalid data type');

--- a/test/integration/cli.test.js
+++ b/test/integration/cli.test.js
@@ -408,7 +408,7 @@ ${figures.cross} prefer-property-order - node:  - Your package.json properties a
 
 ./packages/packageTwo/package.json
 ${figures.warning} license-type - node: license - Type should be a string
-${figures.cross} valid-values-author - node: author - Invalid value for author
+${figures.cross} valid-values-author - node: author - Invalid value for author. Current value is Thomas Lindner. Value values include: TC.
 1 error
 1 warning
 

--- a/test/integration/cli.test.js
+++ b/test/integration/cli.test.js
@@ -373,7 +373,7 @@ ${figures.cross} prefer-property-order - node:  - Your package.json properties a
 
 ./packages/packageTwo/package.json
 ${figures.warning} license-type - node: license - Type should be a string
-${figures.cross} valid-values-author - node: author - Invalid value for author
+${figures.cross} valid-values-author - node: author - Invalid value for author. Current value is Thomas Lindner. Value values include: TC.
 1 error
 1 warning
 

--- a/test/unit/linter/linter.test.ts
+++ b/test/unit/linter/linter.test.ts
@@ -297,7 +297,12 @@ describe('linter Unit Tests', () => {
       const rules = new Rules();
       rules.load();
 
-      const lintIssue = new LintIssue('valid-values-author', Severity.Error, 'author', 'Invalid value for author');
+      const lintIssue = new LintIssue(
+        'valid-values-author',
+        Severity.Error,
+        'author',
+        'Invalid value for author. Current value is Spiderman. Value values include: Peter Parker.'
+      );
       const expected = {
         errorCount: 1,
         ignoreCount: 0,

--- a/test/unit/rules/valid-values-author.test.ts
+++ b/test/unit/rules/valid-values-author.test.ts
@@ -25,7 +25,7 @@ describe('valid-values-author Unit Tests', () => {
       expect(response.lintId).toStrictEqual('valid-values-author');
       expect(response.severity).toStrictEqual('error');
       expect(response.node).toStrictEqual('author');
-      expect(response.lintMessage).toStrictEqual('Invalid value for author');
+      expect(response.lintMessage).toStrictEqual('Invalid value for author. Current value is LastName, FirstName. Value values include: FirstName LastName, FirstName MiddleName LastName.');
     });
   });
 
@@ -55,7 +55,7 @@ describe('valid-values-author Unit Tests', () => {
       expect(response.lintId).toStrictEqual('valid-values-author');
       expect(response.severity).toStrictEqual('error');
       expect(response.node).toStrictEqual('author');
-      expect(response.lintMessage).toStrictEqual('Invalid value for author');
+      expect(response.lintMessage).toStrictEqual('Invalid value for author. Current value is LastName, FirstName. Value values include: FirstName LastName, FirstName MiddleName LastName.');
     });
   });
 

--- a/test/unit/rules/valid-values-author.test.ts
+++ b/test/unit/rules/valid-values-author.test.ts
@@ -25,7 +25,9 @@ describe('valid-values-author Unit Tests', () => {
       expect(response.lintId).toStrictEqual('valid-values-author');
       expect(response.severity).toStrictEqual('error');
       expect(response.node).toStrictEqual('author');
-      expect(response.lintMessage).toStrictEqual('Invalid value for author. Current value is LastName, FirstName. Value values include: FirstName LastName, FirstName MiddleName LastName.');
+      expect(response.lintMessage).toStrictEqual(
+        'Invalid value for author. Current value is LastName, FirstName. Value values include: FirstName LastName, FirstName MiddleName LastName.'
+      );
     });
   });
 
@@ -55,7 +57,9 @@ describe('valid-values-author Unit Tests', () => {
       expect(response.lintId).toStrictEqual('valid-values-author');
       expect(response.severity).toStrictEqual('error');
       expect(response.node).toStrictEqual('author');
-      expect(response.lintMessage).toStrictEqual('Invalid value for author. Current value is LastName, FirstName. Value values include: FirstName LastName, FirstName MiddleName LastName.');
+      expect(response.lintMessage).toStrictEqual(
+        'Invalid value for author. Current value is LastName, FirstName. Value values include: FirstName LastName, FirstName MiddleName LastName.'
+      );
     });
   });
 

--- a/test/unit/rules/valid-values-engines.test.ts
+++ b/test/unit/rules/valid-values-engines.test.ts
@@ -33,7 +33,7 @@ describe('valid-values-engines Unit Tests', () => {
       expect(response.lintId).toStrictEqual('valid-values-engines');
       expect(response.severity).toStrictEqual('error');
       expect(response.node).toStrictEqual('engines');
-      expect(response.lintMessage).toStrictEqual('Invalid value for engines');
+      expect(response.lintMessage).toStrictEqual('Invalid value for engines. Current value is {\"node\":\"^6.0.0\"}. Value values include: {\"node\":\"^6.0.0\",\"npm\":\"^3.0.0\"}, {\"node\":\"^10.0.0\"}.');
     });
   });
 

--- a/test/unit/rules/valid-values-engines.test.ts
+++ b/test/unit/rules/valid-values-engines.test.ts
@@ -33,7 +33,9 @@ describe('valid-values-engines Unit Tests', () => {
       expect(response.lintId).toStrictEqual('valid-values-engines');
       expect(response.severity).toStrictEqual('error');
       expect(response.node).toStrictEqual('engines');
-      expect(response.lintMessage).toStrictEqual('Invalid value for engines. Current value is {\"node\":\"^6.0.0\"}. Value values include: {\"node\":\"^6.0.0\",\"npm\":\"^3.0.0\"}, {\"node\":\"^10.0.0\"}.');
+      expect(response.lintMessage).toStrictEqual(
+        'Invalid value for engines. Current value is {"node":"^6.0.0"}. Value values include: {"node":"^6.0.0","npm":"^3.0.0"}, {"node":"^10.0.0"}.'
+      );
     });
   });
 

--- a/test/unit/rules/valid-values-license.test.ts
+++ b/test/unit/rules/valid-values-license.test.ts
@@ -25,7 +25,7 @@ describe('valid-values-license Unit Tests', () => {
       expect(response.lintId).toStrictEqual('valid-values-license');
       expect(response.severity).toStrictEqual('error');
       expect(response.node).toStrictEqual('license');
-      expect(response.lintMessage).toStrictEqual('Invalid value for license');
+      expect(response.lintMessage).toStrictEqual('Invalid value for license. Current value is MIT. Valid values include: private, unlicensed.');
     });
   });
 

--- a/test/unit/rules/valid-values-license.test.ts
+++ b/test/unit/rules/valid-values-license.test.ts
@@ -25,7 +25,9 @@ describe('valid-values-license Unit Tests', () => {
       expect(response.lintId).toStrictEqual('valid-values-license');
       expect(response.severity).toStrictEqual('error');
       expect(response.node).toStrictEqual('license');
-      expect(response.lintMessage).toStrictEqual('Invalid value for license. Current value is MIT. Valid values include: private, unlicensed.');
+      expect(response.lintMessage).toStrictEqual(
+        'Invalid value for license. Current value is MIT. Valid values include: private, unlicensed.'
+      );
     });
   });
 

--- a/test/unit/rules/valid-values-name-scope.test.ts
+++ b/test/unit/rules/valid-values-name-scope.test.ts
@@ -25,7 +25,9 @@ describe('valid-values-name-scope Unit Tests', () => {
       expect(response.lintId).toStrictEqual('valid-values-name-scope');
       expect(response.severity).toStrictEqual('error');
       expect(response.node).toStrictEqual('name');
-      expect(response.lintMessage).toStrictEqual('Invalid value for name scope. Current value is @great/awesome-package. Valid values include: @cool, @awesome.');
+      expect(response.lintMessage).toStrictEqual(
+        'Invalid value for name scope. Current value is @great/awesome-package. Valid values include: @cool, @awesome.'
+      );
     });
   });
 
@@ -40,7 +42,9 @@ describe('valid-values-name-scope Unit Tests', () => {
       expect(response.lintId).toStrictEqual('valid-values-name-scope');
       expect(response.severity).toStrictEqual('error');
       expect(response.node).toStrictEqual('name');
-      expect(response.lintMessage).toStrictEqual('Invalid value for name scope. Current value is awesome-package. Valid values include: @cool, @awesome.');
+      expect(response.lintMessage).toStrictEqual(
+        'Invalid value for name scope. Current value is awesome-package. Valid values include: @cool, @awesome.'
+      );
     });
   });
 

--- a/test/unit/rules/valid-values-name-scope.test.ts
+++ b/test/unit/rules/valid-values-name-scope.test.ts
@@ -25,7 +25,7 @@ describe('valid-values-name-scope Unit Tests', () => {
       expect(response.lintId).toStrictEqual('valid-values-name-scope');
       expect(response.severity).toStrictEqual('error');
       expect(response.node).toStrictEqual('name');
-      expect(response.lintMessage).toStrictEqual('Invalid value for name scope');
+      expect(response.lintMessage).toStrictEqual('Invalid value for name scope. Current value is @great/awesome-package. Valid values include: @cool, @awesome.');
     });
   });
 
@@ -40,7 +40,7 @@ describe('valid-values-name-scope Unit Tests', () => {
       expect(response.lintId).toStrictEqual('valid-values-name-scope');
       expect(response.severity).toStrictEqual('error');
       expect(response.node).toStrictEqual('name');
-      expect(response.lintMessage).toStrictEqual('Invalid value for name scope');
+      expect(response.lintMessage).toStrictEqual('Invalid value for name scope. Current value is awesome-package. Valid values include: @cool, @awesome.');
     });
   });
 

--- a/test/unit/rules/valid-values-private.test.ts
+++ b/test/unit/rules/valid-values-private.test.ts
@@ -25,7 +25,9 @@ describe('valid-values-private Unit Tests', () => {
       expect(response.lintId).toStrictEqual('valid-values-private');
       expect(response.severity).toStrictEqual('error');
       expect(response.node).toStrictEqual('private');
-      expect(response.lintMessage).toStrictEqual('Invalid value for private');
+      expect(response.lintMessage).toStrictEqual(
+        'Invalid value for private. Current value is true. Valid values include: false.'
+      );
     });
   });
 

--- a/test/unit/rules/valid-values-publishConfig.test.ts
+++ b/test/unit/rules/valid-values-publishConfig.test.ts
@@ -27,7 +27,7 @@ describe('valid-values-publishConfig Unit Tests', () => {
       expect(response.lintId).toStrictEqual('valid-values-publishConfig');
       expect(response.severity).toStrictEqual('error');
       expect(response.node).toStrictEqual('publishConfig');
-      expect(response.lintMessage).toStrictEqual('Invalid value for publishConfig');
+      expect(response.lintMessage).toStrictEqual('Invalid value for publishConfig. Current value is {\"access\":\"public\"}. Value values include: {\"access\":\"private\"}, {\"access\":\"protected\"}.');
     });
   });
 

--- a/test/unit/rules/valid-values-publishConfig.test.ts
+++ b/test/unit/rules/valid-values-publishConfig.test.ts
@@ -27,7 +27,9 @@ describe('valid-values-publishConfig Unit Tests', () => {
       expect(response.lintId).toStrictEqual('valid-values-publishConfig');
       expect(response.severity).toStrictEqual('error');
       expect(response.node).toStrictEqual('publishConfig');
-      expect(response.lintMessage).toStrictEqual('Invalid value for publishConfig. Current value is {\"access\":\"public\"}. Value values include: {\"access\":\"private\"}, {\"access\":\"protected\"}.');
+      expect(response.lintMessage).toStrictEqual(
+        'Invalid value for publishConfig. Current value is {"access":"public"}. Value values include: {"access":"private"}, {"access":"protected"}.'
+      );
     });
   });
 

--- a/website/docs/rules/valid-values/valid-values-author.md
+++ b/website/docs/rules/valid-values/valid-values-author.md
@@ -78,5 +78,6 @@ Enabling this rule will result in an error being generated if the value in `auth
 
 ## History
 
+* Improved messaging when an invalid configuration is detected in version 6.1.0
 * Renamed from author-valid-values to valid-values-author in version 1.0.0
 * Introduced in version 0.1.0

--- a/website/docs/rules/valid-values/valid-values-engines.md
+++ b/website/docs/rules/valid-values/valid-values-engines.md
@@ -66,4 +66,5 @@ Enabling this rule will result in an error being generated if the value in `engi
 
 ## History
 
+* Improved messaging when an invalid configuration is detected in version 6.1.0
 * Introduced in version 3.1.0

--- a/website/docs/rules/valid-values/valid-values-license.md
+++ b/website/docs/rules/valid-values/valid-values-license.md
@@ -54,4 +54,5 @@ Enabling this rule will result in an error being generated if the value in `lice
 
 ## History
 
+* Improved messaging when an invalid configuration is detected in version 6.1.0
 * Introduced in version 1.4.0

--- a/website/docs/rules/valid-values/valid-values-name-scope.md
+++ b/website/docs/rules/valid-values/valid-values-name-scope.md
@@ -60,4 +60,5 @@ Enabling this rule will result in an error being generated if the package `name`
 
 ## History
 
+* Improved messaging when an invalid configuration is detected in version 6.1.0
 * Introduced in version 3.4.0

--- a/website/docs/rules/valid-values/valid-values-private.md
+++ b/website/docs/rules/valid-values/valid-values-private.md
@@ -78,5 +78,6 @@ N/A
 
 ## History
 
+* Improved messaging when an invalid configuration is detected in version 6.1.0
 * Renamed from private-valid-values to valid-values-private in version 1.0.0
 * Introduced in version 0.1.0

--- a/website/docs/rules/valid-values/valid-values-publishConfig.md
+++ b/website/docs/rules/valid-values/valid-values-publishConfig.md
@@ -58,4 +58,5 @@ Enabling this rule will result in an error being generated if the value in `publ
 
 ## History
 
+* Improved messaging when an invalid configuration is detected in version 6.1.0
 * Introduced in version 3.0.0


### PR DESCRIPTION
**Description of change**
Improve lint message when invalid configuration is detected for `valid-values-*` rules.

**Checklist**

  - [x] Unit tests have been added
  - [x] Specific notes for documentation, if applicable
