### PR TITLE
Improve console color constrast

### DIFF
--- a/src/console-reporter.ts
+++ b/src/console-reporter.ts
@@ -12,11 +12,9 @@ const oneFile = 1;
  * @internal
  */
 const printResultSetIssues = (issues: LintIssue[]): void => {
-  // eslint-disable-next-line no-restricted-syntax
-  for (const issue of issues) {
-    // eslint-disable-next-line no-console
+  issues.forEach((issue) => {
     console.log(issue.toString());
-  }
+  });
 };
 
 /**
@@ -26,7 +24,6 @@ const printResultSetIssues = (issues: LintIssue[]): void => {
  * @param quiet True suppress warnings, false show warnings
  * @internal
  */
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const printIndividualResultSet = (resultSet, quiet: boolean): void => {
   const {filePath, issues, ignored, errorCount, warningCount} = resultSet;
 
@@ -59,7 +56,6 @@ const printIndividualResultSet = (resultSet, quiet: boolean): void => {
  * @param quiet True suppress warnings, false show warnings
  * @internal
  */
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const printTotals = (linterOutput, quiet: boolean): void => {
   const {errorCount, warningCount, ignoreCount} = linterOutput;
 
@@ -86,12 +82,10 @@ const printTotals = (linterOutput, quiet: boolean): void => {
  * @param quiet Flag indicating whether to print warnings.
  * @internal
  */
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const write = (linterOutput, quiet: boolean): void => {
-  // eslint-disable-next-line no-restricted-syntax
-  for (const result of linterOutput.results) {
+  linterOutput.results.forEach((result) => {
     printIndividualResultSet(result, quiet);
-  }
+  });
 
   if (linterOutput.results.length > oneFile) {
     printTotals(linterOutput, quiet);

--- a/src/lint-issue.ts
+++ b/src/lint-issue.ts
@@ -60,10 +60,10 @@ export class LintIssue {
    */
   toString(): string {
     const logSymbol = this.severity === Severity.Error ? logSymbols.error : logSymbols.warning;
-    const formattedLintId = chalk.gray.dim(this.lintId);
-    const formattedNode = chalk.gray.bold(this.node);
+    const formattedLintId = chalk.cyan.bold(this.lintId);
+    const formattedNode = chalk.magenta.bold(this.node);
     const formattedMessage =
-      this.severity === Severity.Error ? chalk.bold.red(this.lintMessage) : chalk.yellow(this.lintMessage);
+      this.severity === Severity.Error ? chalk.red.bold(this.lintMessage) : chalk.yellow(this.lintMessage);
 
     return `${logSymbol} ${formattedLintId} - node: ${formattedNode} - ${formattedMessage}`;
   }

--- a/test/unit/lint-issue.test.ts
+++ b/test/unit/lint-issue.test.ts
@@ -29,9 +29,9 @@ describe('LintIssue Unit Tests', () => {
   describe('toString method', () => {
     describe('when the severity is an error', () => {
       test('the formattedMessage should equal', () => {
-        const formattedLintId = chalk.gray.dim('lintId');
-        const formattedNode = chalk.gray.bold('node');
-        const formattedMessage = chalk.bold.red('lintMessage');
+        const formattedLintId = chalk.cyan.bold('lintId');
+        const formattedNode = chalk.magenta.bold('node');
+        const formattedMessage = chalk.red.bold('lintMessage');
         const output = `${logSymbols.error} ${formattedLintId} - node: ${formattedNode} - ${formattedMessage}`;
         const lintIssue = new LintIssue('lintId', Severity.Error, 'node', 'lintMessage');
 
@@ -39,8 +39,8 @@ describe('LintIssue Unit Tests', () => {
       });
 
       test('when an array with one error is passed a formatted message should be returned saying there is one error', () => {
-        const formattedLintId = chalk.gray.dim('lintId');
-        const formattedNode = chalk.gray.bold('node');
+        const formattedLintId = chalk.cyan.bold('lintId');
+        const formattedNode = chalk.magenta.bold('node');
         const formattedMessage = chalk.yellow('lintMessage');
         const output = `${logSymbols.warning} ${formattedLintId} - node: ${formattedNode} - ${formattedMessage}`;
         const lintIssue = new LintIssue('lintId', Severity.Warning, 'node', 'lintMessage');


### PR DESCRIPTION
**Description of change**
Tweak console output color to improve contrast
<img width="1085" alt="image" src="https://user-images.githubusercontent.com/5178550/159131074-3db2e23b-e95c-485b-802a-ece8acfb2650.png">


**Checklist**

  - [x] Unit tests have been added
  - [x] Specific notes for documentation, if applicable
