### PR TITLE
Improve output for no-*-version-* rules

### DIFF
--- a/src/rules/no-caret-version-dependencies.ts
+++ b/src/rules/no-caret-version-dependencies.ts
@@ -1,24 +1,28 @@
 import {PackageJson} from 'type-fest';
-import {doVersContainInvalidRange} from '../validators/dependency-audit';
+import {auditDependenciesForInvalidRange} from '../validators/dependency-audit';
 import {LintIssue} from '../lint-issue';
 import {RuleType} from '../types/rule-type';
 import {Severity} from '../types/severity';
 
 const lintId = 'no-caret-version-dependencies';
 const nodeName = 'dependencies';
-const message = 'You are using an invalid version range. Please do not use ^.';
 
 export const ruleType = RuleType.OptionalObject;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const lint = (packageJsonData: PackageJson | any, severity: Severity, config: any): LintIssue | null => {
   const rangeSpecifier = '^';
+  const auditResult = auditDependenciesForInvalidRange(packageJsonData, nodeName, rangeSpecifier, config);
 
-  if (
-    packageJsonData.hasOwnProperty(nodeName) &&
-    doVersContainInvalidRange(packageJsonData, nodeName, rangeSpecifier, config)
-  ) {
-    return new LintIssue(lintId, severity, nodeName, message);
+  if (packageJsonData.hasOwnProperty(nodeName) && auditResult.hasInvalidRangeVersions) {
+    return new LintIssue(
+      lintId,
+      severity,
+      nodeName,
+      `You are using an invalid version range. Please do not use ^. Invalid ${nodeName} include: ${auditResult.dependenciesWithInvalidVersionRange.join(
+        ', '
+      )}`
+    );
   }
 
   return null;

--- a/src/rules/no-caret-version-devDependencies.ts
+++ b/src/rules/no-caret-version-devDependencies.ts
@@ -1,24 +1,28 @@
 import {PackageJson} from 'type-fest';
-import {doVersContainInvalidRange} from '../validators/dependency-audit';
+import {auditDependenciesForInvalidRange} from '../validators/dependency-audit';
 import {LintIssue} from '../lint-issue';
 import {RuleType} from '../types/rule-type';
 import {Severity} from '../types/severity';
 
 const lintId = 'no-caret-version-devDependencies';
 const nodeName = 'devDependencies';
-const message = 'You are using an invalid version range. Please do not use ^.';
 
 export const ruleType = RuleType.OptionalObject;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const lint = (packageJsonData: PackageJson | any, severity: Severity, config: any): LintIssue | null => {
   const rangeSpecifier = '^';
+  const auditResult = auditDependenciesForInvalidRange(packageJsonData, nodeName, rangeSpecifier, config);
 
-  if (
-    packageJsonData.hasOwnProperty(nodeName) &&
-    doVersContainInvalidRange(packageJsonData, nodeName, rangeSpecifier, config)
-  ) {
-    return new LintIssue(lintId, severity, nodeName, message);
+  if (packageJsonData.hasOwnProperty(nodeName) && auditResult.hasInvalidRangeVersions) {
+    return new LintIssue(
+      lintId,
+      severity,
+      nodeName,
+      `You are using an invalid version range. Please do not use ^. Invalid ${nodeName} include: ${auditResult.dependenciesWithInvalidVersionRange.join(
+        ', '
+      )}`
+    );
   }
 
   return null;

--- a/src/rules/no-tilde-version-dependencies.ts
+++ b/src/rules/no-tilde-version-dependencies.ts
@@ -1,24 +1,28 @@
 import {PackageJson} from 'type-fest';
-import {doVersContainInvalidRange} from '../validators/dependency-audit';
+import {auditDependenciesForInvalidRange} from '../validators/dependency-audit';
 import {LintIssue} from '../lint-issue';
 import {RuleType} from '../types/rule-type';
 import {Severity} from '../types/severity';
 
 const lintId = 'no-tilde-version-dependencies';
 const nodeName = 'dependencies';
-const message = 'You are using an invalid version range. Please do not use ~.';
 
 export const ruleType = RuleType.OptionalObject;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const lint = (packageJsonData: PackageJson | any, severity: Severity, config: any): LintIssue | null => {
   const rangeSpecifier = '~';
+  const auditResult = auditDependenciesForInvalidRange(packageJsonData, nodeName, rangeSpecifier, config);
 
-  if (
-    packageJsonData.hasOwnProperty(nodeName) &&
-    doVersContainInvalidRange(packageJsonData, nodeName, rangeSpecifier, config)
-  ) {
-    return new LintIssue(lintId, severity, nodeName, message);
+  if (packageJsonData.hasOwnProperty(nodeName) && auditResult.hasInvalidRangeVersions) {
+    return new LintIssue(
+      lintId,
+      severity,
+      nodeName,
+      `You are using an invalid version range. Please do not use ~. Invalid ${nodeName} include: ${auditResult.dependenciesWithInvalidVersionRange.join(
+        ', '
+      )}`
+    );
   }
 
   return null;

--- a/src/rules/no-tilde-version-devDependencies.ts
+++ b/src/rules/no-tilde-version-devDependencies.ts
@@ -1,24 +1,28 @@
 import {PackageJson} from 'type-fest';
-import {doVersContainInvalidRange} from '../validators/dependency-audit';
+import {auditDependenciesForInvalidRange} from '../validators/dependency-audit';
 import {LintIssue} from '../lint-issue';
 import {RuleType} from '../types/rule-type';
 import {Severity} from '../types/severity';
 
 const lintId = 'no-tilde-version-devDependencies';
 const nodeName = 'devDependencies';
-const message = 'You are using an invalid version range. Please do not use ~.';
 
 export const ruleType = RuleType.OptionalObject;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const lint = (packageJsonData: PackageJson | any, severity: Severity, config: any): LintIssue | null => {
   const rangeSpecifier = '~';
+  const auditResult = auditDependenciesForInvalidRange(packageJsonData, nodeName, rangeSpecifier, config);
 
-  if (
-    packageJsonData.hasOwnProperty(nodeName) &&
-    doVersContainInvalidRange(packageJsonData, nodeName, rangeSpecifier, config)
-  ) {
-    return new LintIssue(lintId, severity, nodeName, message);
+  if (packageJsonData.hasOwnProperty(nodeName) && auditResult.hasInvalidRangeVersions) {
+    return new LintIssue(
+      lintId,
+      severity,
+      nodeName,
+      `You are using an invalid version range. Please do not use ~. Invalid ${nodeName} include: ${auditResult.dependenciesWithInvalidVersionRange.join(
+        ', '
+      )}`
+    );
   }
 
   return null;

--- a/src/validators/dependency-audit.ts
+++ b/src/validators/dependency-audit.ts
@@ -157,27 +157,40 @@ export const areVersRangesValid = (
   return rangesValid;
 };
 
+
+export interface AuditDependenciesForInvalidRangeResponse {
+  hasInvalidRangeVersions: boolean;
+  dependenciesWithInvalidVersionRange: string[];
+  dependenciesWithoutInvalidVersionRange: string[];
+}
+
 /**
  * Determines if any dependencies have a version string that starts with the specified invalid range
- * @param  {object} packageJsonData  Valid JSON
- * @param  {string} nodeName         Name of a node in the package.json file
- * @param  {string} rangeSpecifier   A version range specifier
- * @param  {object} config           Rule configuration
- * @return {Boolean}                 True if any dependencies versions start with the invalid range, false if they don't.
+ * @param packageJsonData Valid JSON
+ * @param nodeName Name of a node in the package.json file
+ * @param rangeSpecifier A version range specifier
+ * @param config Rule configuration
+ * @return True if any dependencies versions start with the invalid range, false if they don't.
  */
-export const doVersContainInvalidRange = (
+export const auditDependenciesForInvalidRange = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   packageJsonData: PackageJson | any,
   nodeName: string,
   rangeSpecifier: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   config: any
-): boolean => {
-  if (!packageJsonData.hasOwnProperty(nodeName)) {
-    return false;
-  }
+): AuditDependenciesForInvalidRangeResponse => {
+  let hasInvalidRangeVersions = false;
+  const dependenciesWithInvalidVersionRange = [];
+  const dependenciesWithoutInvalidVersionRange = [];
 
-  let containsInvalidVersion = false;
+  if (!packageJsonData.hasOwnProperty(nodeName)) {
+    return {
+      hasInvalidRangeVersions,
+      dependenciesWithInvalidVersionRange,
+      dependenciesWithoutInvalidVersionRange,
+    };
+  }
 
   // eslint-disable-next-line no-restricted-syntax
   for (const dependencyName in packageJsonData[nodeName]) {
@@ -189,11 +202,18 @@ export const doVersContainInvalidRange = (
     const dependencyVersion = packageJsonData[nodeName][dependencyName];
 
     if (doesVersStartsWithRange(dependencyVersion, rangeSpecifier)) {
-      containsInvalidVersion = true;
+      hasInvalidRangeVersions = true;
+      dependenciesWithInvalidVersionRange.push(dependencyName);
+    } else {
+      dependenciesWithoutInvalidVersionRange.push(dependencyName);
     }
   }
 
-  return containsInvalidVersion;
+  return {
+    hasInvalidRangeVersions,
+    dependenciesWithInvalidVersionRange,
+    dependenciesWithoutInvalidVersionRange,
+  };
 };
 
 export interface AbsoluteVersionCheckerResult {

--- a/src/validators/dependency-audit.ts
+++ b/src/validators/dependency-audit.ts
@@ -157,7 +157,6 @@ export const areVersRangesValid = (
   return rangesValid;
 };
 
-
 export interface AuditDependenciesForInvalidRangeResponse {
   hasInvalidRangeVersions: boolean;
   dependenciesWithInvalidVersionRange: string[];

--- a/test/unit/linter/linter.test.ts
+++ b/test/unit/linter/linter.test.ts
@@ -460,7 +460,7 @@ describe('linter Unit Tests', () => {
         'no-caret-version-dependencies',
         Severity.Error,
         'dependencies',
-        'You are using an invalid version range. Please do not use ^.'
+        'You are using an invalid version range. Please do not use ^. Invalid dependencies include: myModule'
       );
       const expected = {
         errorCount: 1,
@@ -520,7 +520,7 @@ describe('linter Unit Tests', () => {
         'no-caret-version-dependencies',
         Severity.Error,
         'dependencies',
-        'You are using an invalid version range. Please do not use ^.'
+        'You are using an invalid version range. Please do not use ^. Invalid dependencies include: myModule'
       );
       const expected = {
         errorCount: 1,

--- a/test/unit/rules/no-caret-version-dependencies.test.ts
+++ b/test/unit/rules/no-caret-version-dependencies.test.ts
@@ -21,7 +21,9 @@ describe('no-caret-version-dependencies Unit Tests', () => {
       expect(response.lintId).toStrictEqual('no-caret-version-dependencies');
       expect(response.severity).toStrictEqual('error');
       expect(response.node).toStrictEqual('dependencies');
-      expect(response.lintMessage).toStrictEqual('You are using an invalid version range. Please do not use ^.');
+      expect(response.lintMessage).toStrictEqual(
+        'You are using an invalid version range. Please do not use ^. Invalid dependencies include: npm-package-json-lint'
+      );
     });
   });
 

--- a/test/unit/rules/no-caret-version-devDependencies.test.ts
+++ b/test/unit/rules/no-caret-version-devDependencies.test.ts
@@ -21,7 +21,9 @@ describe('no-caret-version-devDependencies Unit Tests', () => {
       expect(response.lintId).toStrictEqual('no-caret-version-devDependencies');
       expect(response.severity).toStrictEqual('error');
       expect(response.node).toStrictEqual('devDependencies');
-      expect(response.lintMessage).toStrictEqual('You are using an invalid version range. Please do not use ^.');
+      expect(response.lintMessage).toStrictEqual(
+        'You are using an invalid version range. Please do not use ^. Invalid devDependencies include: npm-package-json-lint'
+      );
     });
   });
 

--- a/test/unit/rules/no-tilde-version-dependencies.test.ts
+++ b/test/unit/rules/no-tilde-version-dependencies.test.ts
@@ -21,7 +21,9 @@ describe('no-tilde-version-dependencies Unit Tests', () => {
       expect(response.lintId).toStrictEqual('no-tilde-version-dependencies');
       expect(response.severity).toStrictEqual('error');
       expect(response.node).toStrictEqual('dependencies');
-      expect(response.lintMessage).toStrictEqual('You are using an invalid version range. Please do not use ~.');
+      expect(response.lintMessage).toStrictEqual(
+        'You are using an invalid version range. Please do not use ~. Invalid dependencies include: npm-package-json-lint'
+      );
     });
   });
 

--- a/test/unit/rules/no-tilde-version-devDependencies.test.ts
+++ b/test/unit/rules/no-tilde-version-devDependencies.test.ts
@@ -21,7 +21,9 @@ describe('no-tilde-version-devDependencies Unit Tests', () => {
       expect(response.lintId).toStrictEqual('no-tilde-version-devDependencies');
       expect(response.severity).toStrictEqual('error');
       expect(response.node).toStrictEqual('devDependencies');
-      expect(response.lintMessage).toStrictEqual('You are using an invalid version range. Please do not use ~.');
+      expect(response.lintMessage).toStrictEqual(
+        'You are using an invalid version range. Please do not use ~. Invalid devDependencies include: npm-package-json-lint'
+      );
     });
   });
 

--- a/test/unit/validators/dependency-audit.test.ts
+++ b/test/unit/validators/dependency-audit.test.ts
@@ -558,7 +558,7 @@ describe('dependency-audit Unit Tests', () => {
     });
   });
 
-  describe('doVersContainInvalidRange method', () => {
+  describe('auditDependenciesForInvalidRange method', () => {
     describe('when the node does not exist in the package.json file', () => {
       test('false should be returned', () => {
         const packageJson = {
@@ -568,9 +568,13 @@ describe('dependency-audit Unit Tests', () => {
             'gulp-npm-package-json-lint': '^2.0.0-rc1',
           },
         };
-        const response = dependencyAudit.doVersContainInvalidRange(packageJson, 'devDependencies', '~', {});
+        const response = dependencyAudit.auditDependenciesForInvalidRange(packageJson, 'devDependencies', '~', {});
 
-        expect(response).toBe(false);
+        expect(response).toStrictEqual({
+          hasInvalidRangeVersions: false,
+          dependenciesWithInvalidVersionRange: [],
+          dependenciesWithoutInvalidVersionRange: [],
+        });
       });
     });
 
@@ -583,9 +587,13 @@ describe('dependency-audit Unit Tests', () => {
             'gulp-npm-package-json-lint': '^2.0.0-rc1',
           },
         };
-        const response = dependencyAudit.doVersContainInvalidRange(packageJson, 'dependencies', '~', {});
+        const response = dependencyAudit.auditDependenciesForInvalidRange(packageJson, 'dependencies', '~', {});
 
-        expect(response).toBe(true);
+        expect(response).toStrictEqual({
+          hasInvalidRangeVersions: true,
+          dependenciesWithInvalidVersionRange: ['grunt-npm-package-json-lint'],
+          dependenciesWithoutInvalidVersionRange: ['npm-package-json-lint', 'gulp-npm-package-json-lint'],
+        });
       });
     });
 
@@ -598,9 +606,17 @@ describe('dependency-audit Unit Tests', () => {
             'gulp-npm-package-json-lint': '^2.0.0-rc1',
           },
         };
-        const response = dependencyAudit.doVersContainInvalidRange(packageJson, 'dependencies', '~', {});
+        const response = dependencyAudit.auditDependenciesForInvalidRange(packageJson, 'dependencies', '~', {});
 
-        expect(response).toBe(false);
+        expect(response).toStrictEqual({
+          hasInvalidRangeVersions: false,
+          dependenciesWithInvalidVersionRange: [],
+          dependenciesWithoutInvalidVersionRange: [
+            'npm-package-json-lint',
+            'grunt-npm-package-json-lint',
+            'gulp-npm-package-json-lint',
+          ],
+        });
       });
     });
 
@@ -613,11 +629,15 @@ describe('dependency-audit Unit Tests', () => {
             'gulp-npm-package-json-lint': '^2.0.0-rc1',
           },
         };
-        const response = dependencyAudit.doVersContainInvalidRange(packageJson, 'dependencies', '~', {
+        const response = dependencyAudit.auditDependenciesForInvalidRange(packageJson, 'dependencies', '~', {
           exceptions: ['npm-package-json-lint', 'grunt-npm-package-json-lint'],
         });
 
-        expect(response).toBe(false);
+        expect(response).toStrictEqual({
+          hasInvalidRangeVersions: false,
+          dependenciesWithInvalidVersionRange: [],
+          dependenciesWithoutInvalidVersionRange: ['gulp-npm-package-json-lint'],
+        });
       });
     });
 
@@ -630,9 +650,13 @@ describe('dependency-audit Unit Tests', () => {
             'gulp-npm-package-json-lint': '^2.0.0-rc1',
           },
         };
-        const response = dependencyAudit.doVersContainInvalidRange(packageJson, 'dependencies', '~', {});
+        const response = dependencyAudit.auditDependenciesForInvalidRange(packageJson, 'dependencies', '~', {});
 
-        expect(response).toBe(true);
+        expect(response).toStrictEqual({
+          hasInvalidRangeVersions: true,
+          dependenciesWithInvalidVersionRange: ['npm-package-json-lint', 'grunt-npm-package-json-lint'],
+          dependenciesWithoutInvalidVersionRange: ['gulp-npm-package-json-lint'],
+        });
       });
     });
   });

--- a/website/docs/rules/dependencies/no-caret-version-dependencies.md
+++ b/website/docs/rules/dependencies/no-caret-version-dependencies.md
@@ -101,4 +101,5 @@ With exceptions
 
 ## History
 
+* Improved messaging when an invalid configuration is detected in version 6.3.0
 * Introduced in version 3.2.0

--- a/website/docs/rules/dependencies/no-caret-version-devDependencies.md
+++ b/website/docs/rules/dependencies/no-caret-version-devDependencies.md
@@ -101,4 +101,5 @@ With exceptions
 
 ## History
 
+* Improved messaging when an invalid configuration is detected in version 6.3.0
 * Introduced in version 3.2.0

--- a/website/docs/rules/dependencies/no-tilde-version-dependencies.md
+++ b/website/docs/rules/dependencies/no-tilde-version-dependencies.md
@@ -101,4 +101,5 @@ With exceptions
 
 ## History
 
+* Improved messaging when an invalid configuration is detected in version 6.3.0
 * Introduced in version 3.2.0

--- a/website/docs/rules/dependencies/no-tilde-version-devDependencies.md
+++ b/website/docs/rules/dependencies/no-tilde-version-devDependencies.md
@@ -101,4 +101,5 @@ With exceptions
 
 ## History
 
+* Improved messaging when an invalid configuration is detected in version 6.3.0
 * Introduced in version 3.2.0


### PR DESCRIPTION
**Description of change**
Improve lint message when invalid configuration is detected for no-*-version-* rules.

**Checklist**

  - [x] Unit tests have been added
  - [x] Specific notes for documentation, if applicable
