### PR TITLE
Use `v3` for `actions/setup-node` in GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3.4.1
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
       - run: npm ci --no-progress
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v3.4.1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       - run: npm ci --no-progress

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3.4.1
+    - uses: actions/setup-node@v3
       with:
         node-version: '14'
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3.4.1
+    - uses: actions/setup-node@v3
       with:
         node-version: '14'
         registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
**Description of change**
This PR changes the version of `actions/setup-node` to `v3` so that the latest version `3.x` is used in GitHub Actions. This will reduce the number of Dependabot PRs.

**Checklist**

  - [ ] Unit tests have been added
  - [ ] Specific notes for documentation, if applicable
