### PR TITLE
fix: "Get started" leads to 404

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -48,7 +48,7 @@ const Index = () => {
 
             <Link
               className='button button--secondary button--lg'
-              to={useBaseUrl('docs/index')}
+              to={useBaseUrl('docs/install')}
             >
               Get Started
             </Link>


### PR DESCRIPTION
**Description of change**

Clicking the "Get started" link on the homepage leads to a 404. I don't know where this link was intended to lead, but I can imagine it was intended to lead to `/docs/install`.


**Checklist**

  - [ ] ~~Unit tests have been added~~
  - [x] Specific notes for documentation, if applicable
