### PR TITLE
Bump ajv from 6.12.6 to 6.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "ajv": "6.12.6",
+        "ajv": "6.14.0",
         "ajv-errors": "1.0.1",
         "chalk": "4.1.2",
         "cosmiconfig": "8.3.6",
@@ -2416,9 +2416,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -3692,23 +3692,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
@@ -5801,6 +5784,24 @@
       },
       "peerDependencies": {
         "npm-package-json-lint": "^10.0.0"
+      }
+    },
+    "node_modules/npm-package-json-lint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/npm-package-json-lint/node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:ci": "jest --runInBand"
   },
   "dependencies": {
-    "ajv": "6.12.6",
+    "ajv": "6.14.0",
     "ajv-errors": "1.0.1",
     "chalk": "4.1.2",
     "cosmiconfig": "8.3.6",


### PR DESCRIPTION
**Description of change**

Bump ajv from 6.12.6 to 6.14.0 to resolve GHSA-2g4f-4pwh-qvx6. Users of `npm-package-json-lint` can't upgrade independently because the version is pinned.
See also https://github.com/tclindner/npm-package-json-lint/pull/1708#issuecomment-4205948233

**Checklist**

  - [x] Unit tests have been added
  - [x] Specific notes for documentation, if applicable
