### PR TITLE
fix: replace globby with minimatch in applyOverrides to fix severe slowdown with overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "is-plain-obj": "3.0.0",
         "jsonc-parser": "3.3.1",
         "meow": "9.0.0",
+        "minimatch": "10.2.4",
         "semver": "7.7.4",
         "slash": "3.0.0",
         "strip-json-comments": "3.1.1",
@@ -2716,7 +2717,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -2749,7 +2749,6 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -5594,7 +5593,6 @@
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
       "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "ajv": "6.14.0",
+    "minimatch": "10.2.4",
     "ajv-errors": "1.0.1",
     "chalk": "4.1.2",
     "cosmiconfig": "8.3.6",

--- a/src/config/applyOverrides.ts
+++ b/src/config/applyOverrides.ts
@@ -23,7 +23,7 @@ export const applyOverrides = (cwd: string, filePath: string, rules: any, overri
   if (overrides) {
     // Compute the relative path once and reuse across all override checks.
     // Normalize to forward slashes so patterns work consistently across platforms.
-    const relativeFilePath = path.relative(cwd, filePath).replace(/\\/g, '/');
+    const relativeFilePath = path.relative(cwd, filePath).replaceAll(/\\/g, '/');
 
     overrides.forEach((override) => {
       const filteredPatterns = override.patterns.filter((pattern: string) => pattern.length);

--- a/src/config/applyOverrides.ts
+++ b/src/config/applyOverrides.ts
@@ -23,7 +23,8 @@ export const applyOverrides = (cwd: string, filePath: string, rules: any, overri
   if (overrides) {
     // Compute the relative path once and reuse across all override checks.
     // Normalize to forward slashes so patterns work consistently across platforms.
-    const relativeFilePath = path.relative(cwd, filePath).replaceAll(/\\/g, '/');
+    // eslint-disable-next-line unicorn/prefer-string-replace-all
+    const relativeFilePath = path.relative(cwd, filePath).replace(/\\/g, '/');
 
     overrides.forEach((override) => {
       const filteredPatterns = override.patterns.filter((pattern: string) => pattern.length);

--- a/src/config/applyOverrides.ts
+++ b/src/config/applyOverrides.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import globby from 'globby';
+import {minimatch} from 'minimatch';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const debug = require('debug')('npm-package-json-lint:applyOverrides');
@@ -7,7 +7,7 @@ const debug = require('debug')('npm-package-json-lint:applyOverrides');
 /**
  * Applies values from the 'overrides' field in a configuration file.
  * @param {string} cwd       The current working directory.
- * @param {Object} filePath  The file path of the file being linted.
+ * @param {string} filePath  The file path of the file being linted.
  * @param {Object} rules     Rules object
  * @param {Object} overrides Overrides object
  * @returns {Object} A new configuration object with all of the 'overrides' applied.
@@ -21,26 +21,27 @@ export const applyOverrides = (cwd: string, filePath: string, rules: any, overri
   debug(overrides);
 
   if (overrides) {
+    // Compute the relative path once and reuse across all override checks.
+    // Normalize to forward slashes so patterns work consistently across platforms.
+    const relativeFilePath = path.relative(cwd, filePath).replace(/\\/g, '/');
+
     overrides.forEach((override) => {
-      const filteredPatterns = override.patterns.filter((pattern) => pattern.length);
-      const transformedPatterns = filteredPatterns.map((pattern) =>
+      const filteredPatterns = override.patterns.filter((pattern: string) => pattern.length);
+      const transformedPatterns = filteredPatterns.map((pattern: string) =>
         pattern.endsWith(`/package.json`) ? pattern : `${pattern}/package.json`,
       );
 
-      const globFiles = globby.sync(transformedPatterns, {
-        cwd,
-        gitignore: true,
-      });
+      // Strip leading './' from patterns so they match the output of path.relative(),
+      // which never includes a leading './'.
+      const matches = transformedPatterns.some((pattern: string) =>
+        minimatch(relativeFilePath, pattern.replace(/^\.\//, ''), {dot: true}),
+      );
 
-      debug('globFiles');
-      debug(globFiles);
-      globFiles.forEach((globFile) => {
-        const globbedFilePath = path.resolve(cwd, globFile);
+      debug('relativeFilePath: %s, patterns: %o, matches: %s', relativeFilePath, transformedPatterns, matches);
 
-        if (filePath === globbedFilePath) {
-          finalRules = {...finalRules, ...override.rules};
-        }
-      });
+      if (matches) {
+        finalRules = {...finalRules, ...override.rules};
+      }
     });
   }
 

--- a/test/unit/config/applyOverrides.test.ts
+++ b/test/unit/config/applyOverrides.test.ts
@@ -1,83 +1,78 @@
-import path from 'node:path';
-import globby from 'globby';
 import {applyOverrides} from '../../../src/config/applyOverrides';
 
-jest.mock('globby');
-jest.mock('path');
-
 describe('applyOverrides Unit Tests', () => {
-  test('pattern match', () => {
-    const cwd = process.cwd();
-    const filePath = './package.json';
-    const rules = {
-      'require-name': 'error',
-    };
+  const cwd = '/project';
+
+  test('applies rules from all matching overrides in order', () => {
+    const filePath = '/project/packages/config/package.json';
+    const rules = {'require-name': 'error'};
     const overrides = [
       {
         patterns: ['**'],
-        rules: {
-          'require-name': 'off',
-        },
+        rules: {'require-name': 'off'},
       },
       {
-        patterns: ['*/package.json'],
-        rules: {
-          'require-name': 'warning',
-        },
+        patterns: ['packages/config'],
+        rules: {'require-name': 'warning'},
       },
     ];
 
-    jest.spyOn(globby, 'sync').mockReturnValue(['./package.json']);
-    jest.spyOn(path, 'resolve').mockReturnValue('./package.json');
+    const result = applyOverrides(cwd, filePath, rules, overrides);
 
-    const results = applyOverrides(cwd, filePath, rules, overrides);
-
-    expect(results).toStrictEqual({
-      'require-name': 'warning',
-    });
+    expect(result).toStrictEqual({'require-name': 'warning'});
   });
 
-  test('pattern miss', () => {
-    const cwd = process.cwd();
-    const filePath = './test/package.json';
-    const rules = {
-      'require-name': 'error',
-    };
+  test('keeps original rules when no pattern matches', () => {
+    const filePath = '/project/apps/api/package.json';
+    const rules = {'require-name': 'error'};
     const overrides = [
       {
-        patterns: ['**'],
-        rules: {
-          'require-name': 'off',
-        },
-      },
-      {
-        patterns: ['*/package.json'],
-        rules: {
-          'require-name': 'warning',
-        },
+        patterns: ['packages/config'],
+        rules: {'require-name': 'warning'},
       },
     ];
 
-    jest.spyOn(globby, 'sync').mockReturnValue(['./package.json']);
-    jest.spyOn(path, 'resolve').mockReturnValue('./package.json');
+    const result = applyOverrides(cwd, filePath, rules, overrides);
 
-    const results = applyOverrides(cwd, filePath, rules, overrides);
-
-    expect(results).toStrictEqual({
-      'require-name': 'error',
-    });
+    expect(result).toStrictEqual({'require-name': 'error'});
   });
 
   test('no overrides', () => {
-    const cwd = process.cwd();
-    const filePath = './test/package.json';
-    const rules = {
-      'require-name': 'error',
-    };
-    const results = applyOverrides(cwd, filePath, rules);
+    const filePath = '/project/packages/config/package.json';
+    const rules = {'require-name': 'error'};
 
-    expect(results).toStrictEqual({
-      'require-name': 'error',
-    });
+    const result = applyOverrides(cwd, filePath, rules);
+
+    expect(result).toStrictEqual({'require-name': 'error'});
+  });
+
+  test('matches root package.json via ./ pattern', () => {
+    const filePath = '/project/package.json';
+    const rules = {'require-main': 'error'};
+    const overrides = [
+      {
+        patterns: ['./package.json'],
+        rules: {'require-main': 'off'},
+      },
+    ];
+
+    const result = applyOverrides(cwd, filePath, rules, overrides);
+
+    expect(result).toStrictEqual({'require-main': 'off'});
+  });
+
+  test('skips empty patterns', () => {
+    const filePath = '/project/packages/config/package.json';
+    const rules = {'require-name': 'error'};
+    const overrides = [
+      {
+        patterns: ['', 'packages/config'],
+        rules: {'require-name': 'warning'},
+      },
+    ];
+
+    const result = applyOverrides(cwd, filePath, rules, overrides);
+
+    expect(result).toStrictEqual({'require-name': 'warning'});
   });
 });


### PR DESCRIPTION
**Description of change**
While using this in my project I noticed that having even a single override in
my config caused lint times to jump from under 1 second to 20+ seconds. After
digging into the source I traced it back to `applyOverrides`.

The function was calling `globby.sync()` once per file per override — with
`gitignore: true`, each call re-reads `.gitignore` and traverses the full
filesystem. In a monorepo with ~30 package.json files and a single override,
that's ~30 filesystem traversals where zero are needed.

## Fix

The fix is to pre-compute the file's relative path once, then use `minimatch`
to test it against each pattern directly — no filesystem access needed since
the file path is already known.

`minimatch` is already present as a transitive dependency through `globby`, but
this PR adds it explicitly to `dependencies` to make the intent clear and protect
against it disappearing if `globby`'s internals ever change.

`globby` is untouched in `getFileList.ts`, where actual filesystem traversal is
the correct behavior.

## Tests

Updated `applyOverrides.test.ts` to remove the `globby`/`path` mocks (no longer
relevant) and use real absolute paths that reflect how the function is called
in practice.

## Documentation

No documentation updates needed — this is an internal implementation detail
with no changes to public API or configuration.

**Checklist**

  - [x] Unit tests have been added
  - [x] Specific notes for documentation, if applicable
