### PR TITLE
Replace is-plain-obj with local util

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "debug": "4.4.3",
         "globby": "11.1.0",
         "ignore": "5.3.2",
-        "is-plain-obj": "3.0.0",
         "jsonc-parser": "3.3.1",
         "meow": "9.0.0",
         "minimatch": "10.2.4",
@@ -4537,7 +4536,9 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
       "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "debug": "4.4.3",
     "globby": "11.1.0",
     "ignore": "5.3.2",
-    "is-plain-obj": "3.0.0",
     "jsonc-parser": "3.3.1",
     "meow": "9.0.0",
     "semver": "7.7.4",

--- a/src/npm-package-json-lint.ts
+++ b/src/npm-package-json-lint.ts
@@ -1,6 +1,6 @@
-import isPlainObj from 'is-plain-obj';
 import slash from 'slash';
 import type {PackageJson} from 'type-fest';
+import {isPlainObj} from './utils/isPlainObj';
 import {Config} from './configuration';
 import {Rules} from './native-rules';
 import {executeOnPackageJsonFiles, executeOnPackageJsonObject, OverallLintingResult} from './linter/linter';

--- a/src/utils/isPlainObj.ts
+++ b/src/utils/isPlainObj.ts
@@ -1,0 +1,13 @@
+export const isPlainObj = (value: unknown): boolean => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+
+  return (
+    (prototype === null || prototype === Object.prototype || Object.getPrototypeOf(prototype) === null) &&
+    !(Symbol.toStringTag in value) &&
+    !(Symbol.iterator in value)
+  );
+};

--- a/src/validators/type.ts
+++ b/src/validators/type.ts
@@ -1,5 +1,5 @@
-import isPlainObj from 'is-plain-obj';
 import type {PackageJson} from 'type-fest';
+import {isPlainObj} from '../utils/isPlainObj';
 
 /**
  * Determines whether or not the node's value is an Array


### PR DESCRIPTION
**Description of change**
Remove external is-plain-obj dependency and add a local isPlainObj implementation (src/utils/isPlainObj.ts). Update imports in src/npm-package-json-lint.ts and src/validators/type.ts to use the new utility, and remove is-plain-obj from package.json.

**Checklist**

  - [x] Unit tests have been added
  - [x] Specific notes for documentation, if applicable
