### PR TITLE
Add prefer-provenance rule

### DIFF
--- a/src/rules/prefer-provenance.ts
+++ b/src/rules/prefer-provenance.ts
@@ -1,0 +1,23 @@
+import type {PackageJson} from 'type-fest';
+import {LintIssue} from '../lint-issue';
+import {RuleType} from '../types/rule-type';
+import {Severity} from '../types/severity';
+
+const lintId = 'prefer-provenance';
+const nodeName = 'publishConfig.provenance';
+const message = 'publishConfig.provenance should be true unless private is true';
+
+export const ruleType = RuleType.Standard;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const lint = (packageJsonData: PackageJson | any, severity: Severity): LintIssue | null => {
+  if (packageJsonData.private === true) {
+    return null;
+  }
+
+  if (packageJsonData.publishConfig?.provenance !== true) {
+    return new LintIssue(lintId, severity, nodeName, message);
+  }
+
+  return null;
+};

--- a/test/unit/rules/prefer-provenance.test.ts
+++ b/test/unit/rules/prefer-provenance.test.ts
@@ -1,0 +1,63 @@
+import {lint, ruleType} from '../../../src/rules/prefer-provenance';
+import {Severity} from '../../../src/types/severity';
+
+describe('prefer-provenance Unit Tests', () => {
+  describe('a rule type value should be exported', () => {
+    test('it should equal "standard"', () => {
+      expect(ruleType).toStrictEqual('standard');
+    });
+  });
+
+  describe('when private is true', () => {
+    test('true should be returned', () => {
+      const packageJsonData = {
+        private: true,
+      };
+      const response = lint(packageJsonData, Severity.Error);
+
+      expect(response).toBeNull();
+    });
+  });
+
+  describe('when private is not true and provenance is true', () => {
+    test('true should be returned', () => {
+      const packageJsonData = {
+        publishConfig: {
+          provenance: true,
+        },
+      };
+      const response = lint(packageJsonData, Severity.Error);
+
+      expect(response).toBeNull();
+    });
+  });
+
+  describe('when private is not true and publishConfig is missing', () => {
+    test('LintIssue object should be returned', () => {
+      const packageJsonData = {};
+      const response = lint(packageJsonData, Severity.Error);
+
+      expect(response.lintId).toStrictEqual('prefer-provenance');
+      expect(response.severity).toStrictEqual('error');
+      expect(response.node).toStrictEqual('publishConfig.provenance');
+      expect(response.lintMessage).toStrictEqual('publishConfig.provenance should be true unless private is true');
+    });
+  });
+
+  describe('when private is not true and provenance is false', () => {
+    test('LintIssue object should be returned', () => {
+      const packageJsonData = {
+        private: false,
+        publishConfig: {
+          provenance: false,
+        },
+      };
+      const response = lint(packageJsonData, Severity.Error);
+
+      expect(response.lintId).toStrictEqual('prefer-provenance');
+      expect(response.severity).toStrictEqual('error');
+      expect(response.node).toStrictEqual('publishConfig.provenance');
+      expect(response.lintMessage).toStrictEqual('publishConfig.provenance should be true unless private is true');
+    });
+  });
+});

--- a/website/docs/rules.md
+++ b/website/docs/rules.md
@@ -161,6 +161,7 @@ Rules allow npm-package-json-lint to be fully customizable. npm-package-json-lin
 > Generates an error if the package.json properties fail to meet the desired requirements
 
 * [prefer-property-order](rules/package-json-properties/prefer-property-order.md)
+* [prefer-provenance](rules/package-json-properties/prefer-provenance.md)
 * [no-duplicate-properties](rules/package-json-properties/no-duplicate-properties.md)
 
 

--- a/website/docs/rules/package-json-properties/prefer-provenance.md
+++ b/website/docs/rules/package-json-properties/prefer-provenance.md
@@ -1,0 +1,57 @@
+---
+id: prefer-provenance
+title: prefer-provenance
+---
+
+Enabling this rule will result in an error being generated if `publishConfig.provenance` is not `true` (unless `private` is set to `true`, which means the package is not published).
+
+## Example .npmpackagejsonlintrc configuration
+
+```json
+{
+  "rules": {
+    "prefer-provenance": "error"
+  }
+}
+```
+
+## Rule Details
+
+### *Incorrect* example(s)
+
+```json
+{
+  "name": "packageName",
+  "publishConfig": {
+    "provenance": false
+  }
+}
+```
+
+```json
+{
+  "name": "packageName"
+}
+```
+
+### *Correct* example(s)
+
+```json
+{
+  "name": "packageName",
+  "publishConfig": {
+    "provenance": true
+  }
+}
+```
+
+```json
+{
+  "name": "packageName",
+  "private": true
+}
+```
+
+## History
+
+* Introduced in version 10.4.0


### PR DESCRIPTION
**Description of change**

If you try to enforce that your packages are published with provenance, you can use the existing `publishConfig` rules, but if a package is not published (`"private": true`), it doesn't make sense to enforce provenance.  This adds a new rule that checks provenance and takes into account whether the package is published.

The change is complete with unit tests and website docs (added the current next minor version in docs).

**Checklist**

  - [x] Unit tests have been added
  - [x] Specific notes for documentation, if applicable
