### PR TITLE
fix: Path to types

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dist"
   ],
   "main": "dist/api.js",
-  "types": "dist/src/api.d.ts",
+  "types": "dist/api.d.ts",
   "scripts": {
     "build": "tsdown",
     "eslint": "eslint .",


### PR DESCRIPTION
Correct the path to the types. Currently, the path points to the `dist/src/` directory, but the `src/` subdirectory does not exist (since [v10.2.1](https://github.com/tclindner/npm-package-json-lint/releases/tag/v10.2.1)). Maybe because of https://github.com/tclindner/npm-package-json-lint/pull/1760

**Checklist**

  - [ ] Unit tests have been added
  - [ ] Specific notes for documentation, if applicable
