### PR TITLE
build(deps-dev): Bump eslint-plugin-unicorn from 65.0.1 to 66.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "eslint-plugin-import-x": "4.17.1",
         "eslint-plugin-jest": "29.15.5",
         "eslint-plugin-prettier": "5.5.6",
-        "eslint-plugin-unicorn": "65.0.1",
+        "eslint-plugin-unicorn": "66.0.0",
         "globals": "17.7.0",
         "jest": "30.4.2",
         "npm-package-json-lint-config-default": "9.0.1",
@@ -226,9 +226,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3859,36 +3859,37 @@
       }
     },
     "node_modules/eslint-plugin-unicorn": {
-      "version": "65.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-65.0.1.tgz",
-      "integrity": "sha512-daCrQrgxOoOz2uMPWB3Y3vvv/5q+ncwICI8IjoebiwtW87CaY4tAN5EEiRXTYVnf7qi1v1BGBdHOSnZLV0rx6A==",
+      "version": "66.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-66.0.0.tgz",
+      "integrity": "sha512-+ywdy8T3foyZ2t3nRBujGa3vfOVMobHIi5iLB0L+fogdVO3EiUJ4BAyIacogWytnweLw3hgT70LQL9KoKTY/kA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "@eslint-community/eslint-utils": "^4.9.1",
+        "browserslist": "^4.28.2",
         "change-case": "^5.4.4",
         "ci-info": "^4.4.0",
         "core-js-compat": "^3.49.0",
         "detect-indent": "^7.0.2",
         "find-up-simple": "^1.0.1",
-        "globals": "^17.4.0",
+        "globals": "^17.6.0",
         "indent-string": "^5.0.0",
         "is-builtin-module": "^5.0.0",
         "jsesc": "^3.1.0",
         "pluralize": "^8.0.0",
-        "regjsparser": "^0.13.0",
-        "semver": "^7.7.4",
+        "regjsparser": "^0.13.1",
+        "semver": "^7.8.4",
         "strip-indent": "^4.1.1"
       },
       "engines": {
-        "node": "^20.10.0 || >=21.0.0"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
       },
       "peerDependencies": {
-        "eslint": ">=9.38.0"
+        "eslint": ">=10.4"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-import-x": "4.17.1",
     "eslint-plugin-jest": "29.15.5",
     "eslint-plugin-prettier": "5.5.6",
-    "eslint-plugin-unicorn": "65.0.1",
+    "eslint-plugin-unicorn": "66.0.0",
     "globals": "17.7.0",
     "jest": "30.4.2",
     "npm-package-json-lint-config-default": "9.0.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,7 @@ const exitCodes = {
   exceedMaxWarnings: 4,
 };
 
-// configure cli
+// configure CLI
 const cli = meow(
   `
       Usage
@@ -91,7 +91,7 @@ if (patterns.length === noPatternsProvided) {
   debug(`No lint targets provided`);
   console.log(chalk.red.bold('No lint targets provided'));
 
-  const exitCode = flags.allowEmptyTargets ? exitCodes.zeroClean : exitCodes.oneMissingTarget;
+  const exitCode = exitCodes[flags.allowEmptyTargets ? 'zeroClean' : 'oneMissingTarget'];
 
   process.exit(exitCode);
 }

--- a/src/config/ConfigSchema.ts
+++ b/src/config/ConfigSchema.ts
@@ -1,9 +1,21 @@
 import Ajv from 'ajv';
 import ajvErrors from 'ajv-errors';
 
-const ajv = new Ajv({allErrors: true});
+let ajvInstance: Ajv | undefined;
 
-ajvErrors(ajv);
+/**
+ * Lazily creates (and memoizes) the shared Ajv instance.
+ *
+ * @returns {Ajv} The shared Ajv instance.
+ */
+const getAjv = (): Ajv => {
+  if (!ajvInstance) {
+    ajvInstance = new Ajv({allErrors: true});
+    ajvErrors(ajvInstance);
+  }
+
+  return ajvInstance;
+};
 
 /**
  * Formats an array of schema validation errors.
@@ -137,11 +149,11 @@ const configurationSchema = {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const isStandardRuleSchemaValid = (ruleConfig: any): any => {
-  const validate = ajv.compile(standardRuleSchema);
+  const validate = getAjv().compile(standardRuleSchema);
   const isValid = validate(ruleConfig);
 
   if (!isValid) {
-    throw new Error(`${formatSchemaErrors(validate.errors)}`);
+    throw new Error(formatSchemaErrors(validate.errors));
   }
 
   return true;
@@ -156,11 +168,11 @@ export const isStandardRuleSchemaValid = (ruleConfig: any): any => {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const isArrayRuleSchemaValid = (ruleConfig: any, minItems: any): any => {
-  const validate = ajv.compile(arrayRuleSchema(minItems));
+  const validate = getAjv().compile(arrayRuleSchema(minItems));
   const isValid = validate(ruleConfig);
 
   if (!isValid) {
-    throw new Error(`${formatSchemaErrors(validate.errors)}`);
+    throw new Error(formatSchemaErrors(validate.errors));
   }
 
   return true;
@@ -174,11 +186,11 @@ export const isArrayRuleSchemaValid = (ruleConfig: any, minItems: any): any => {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const isObjectRuleSchemaValid = (ruleConfig: any): any => {
-  const validate = ajv.compile(objectRuleSchema);
+  const validate = getAjv().compile(objectRuleSchema);
   const isValid = validate(ruleConfig);
 
   if (!isValid) {
-    throw new Error(`${formatSchemaErrors(validate.errors)}`);
+    throw new Error(formatSchemaErrors(validate.errors));
   }
 
   return true;
@@ -192,11 +204,11 @@ export const isObjectRuleSchemaValid = (ruleConfig: any): any => {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const isOptionalObjExceptSchemaValid = (ruleConfig: any): any => {
-  const validate = ajv.compile(optionalObjExceptionsSchema);
+  const validate = getAjv().compile(optionalObjExceptionsSchema);
   const isValid = validate(ruleConfig);
 
   if (!isValid) {
-    throw new Error(`${formatSchemaErrors(validate.errors)}`);
+    throw new Error(formatSchemaErrors(validate.errors));
   }
 
   return true;
@@ -211,7 +223,7 @@ export const isOptionalObjExceptSchemaValid = (ruleConfig: any): any => {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const isConfigObjectSchemaValid = (config: any, source: any): any => {
-  const validate = ajv.compile(configurationSchema);
+  const validate = getAjv().compile(configurationSchema);
   const isValid = validate(config);
 
   if (!isValid) {

--- a/src/config/ConfigValidator.ts
+++ b/src/config/ConfigValidator.ts
@@ -36,11 +36,11 @@ const isObjectRuleConfigValid = (ruleConfig: any): any => {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const isOptionalObjRuleConfigValid = (ruleConfig: any): any => {
-  const object = 1;
-
   if (typeof ruleConfig === 'string') {
     return isStandardRuleSchemaValid(ruleConfig);
   }
+
+  const object = 1;
 
   if (isObjectRuleSchemaValid(ruleConfig) && ruleConfig[object].hasOwnProperty('exceptions')) {
     return isOptionalObjExceptSchemaValid(ruleConfig[object].exceptions);
@@ -139,6 +139,7 @@ export const validateRules = (rulesConfig: any, source: any, rules: any): any =>
     return;
   }
 
+  // eslint-disable-next-line unicorn/no-for-each -- for...of is banned by no-restricted-syntax in this project
   Object.keys(rulesConfig).forEach((ruleName) => {
     const ruleModule = rules.get(ruleName);
 

--- a/src/config/applyExtendsIfSpecified.ts
+++ b/src/config/applyExtendsIfSpecified.ts
@@ -15,11 +15,7 @@ const debug = require('debug')('npm-package-json-lint:applyExtendsIfSpecified');
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const applyExtends = (config: any, parentName: any, originalFilePath: any): any => {
-  let configExtends = config.extends;
-
-  if (!Array.isArray(config.extends)) {
-    configExtends = [config.extends];
-  }
+  const configExtends = Array.isArray(config.extends) ? config.extends : [config.extends];
 
   // eslint-disable-next-line unicorn/no-array-reduce
   return configExtends.reduceRight((previousConfig, moduleName) => {

--- a/src/config/applyOverrides.ts
+++ b/src/config/applyOverrides.ts
@@ -26,6 +26,7 @@ export const applyOverrides = (cwd: string, filePath: string, rules: any, overri
     // eslint-disable-next-line unicorn/prefer-string-replace-all
     const relativeFilePath = path.relative(cwd, filePath).replace(/\\/g, '/');
 
+    // eslint-disable-next-line unicorn/no-for-each -- for...of is banned by no-restricted-syntax in this project
     overrides.forEach((override) => {
       const filteredPatterns = override.patterns.filter((pattern: string) => pattern.length);
       const transformedPatterns = filteredPatterns.map((pattern: string) =>

--- a/src/console-reporter.ts
+++ b/src/console-reporter.ts
@@ -12,6 +12,7 @@ const oneFile = 1;
  * @internal
  */
 const printResultSetIssues = (issues: LintIssue[]): void => {
+  // eslint-disable-next-line unicorn/no-for-each -- for...of is banned by no-restricted-syntax in this project
   issues.forEach((issue) => {
     console.log(issue.toString());
   });
@@ -83,6 +84,7 @@ const printTotals = (linterOutput, quiet: boolean): void => {
  * @internal
  */
 export const write = (linterOutput, quiet: boolean): void => {
+  // eslint-disable-next-line unicorn/no-for-each -- for...of is banned by no-restricted-syntax in this project
   linterOutput.results.forEach((result) => {
     printIndividualResultSet(result, quiet);
   });

--- a/src/file-parser.ts
+++ b/src/file-parser.ts
@@ -16,7 +16,7 @@ const requireFile = (fileName: string): NodeRequire => require(fileName);
  * @param fileName String file path of file to load
  * @internal
  */
-const readFile = (fileName: string): string => fs.readFileSync(fileName, 'utf8').replace(/^\uFEFF/, '');
+const readFile = (fileName: string): string => fs.readFileSync(fileName, 'utf8').replace(/^\u{FEFF}/u, '');
 
 /**
  * Helper method for throwing errors when file fails to load.

--- a/src/lint-issue.ts
+++ b/src/lint-issue.ts
@@ -58,10 +58,9 @@ export class LintIssue {
    * @returns {string} Human-friendly message about the lint issue
    */
   toString(): string {
-    const formattedSeverity =
-      this.severity === Severity.Error
-        ? chalk.bgRedBright(this.severity.toUpperCase())
-        : chalk.bgYellowBright(this.severity.toUpperCase());
+    const formattedSeverity = chalk[this.severity === Severity.Error ? 'bgRedBright' : 'bgYellowBright'](
+      this.severity.toUpperCase(),
+    );
     const formattedLintId = chalk.cyan.bold(this.lintId);
     const formattedNode = chalk.magenta.bold(this.node);
     const formattedMessage =

--- a/src/native-rules.ts
+++ b/src/native-rules.ts
@@ -26,6 +26,7 @@ export class Rules {
     const rulesDirectory = path.join(__dirname, 'rules');
 
     try {
+      // eslint-disable-next-line unicorn/no-for-each -- for...of is banned by no-restricted-syntax in this project
       readdirSync(rulesDirectory).forEach((filePath) => {
         const beginIndex = 0;
         const endIndex = -3;

--- a/src/npm-package-json-lint.ts
+++ b/src/npm-package-json-lint.ts
@@ -43,6 +43,7 @@ const areRequiredOptionsValid = (packageJsonObject: PackageJson | any, patterns:
 const getErrorResults = (results: PackageJsonFileLintingResult[]): PackageJsonFileLintingResult[] => {
   const filtered = [];
 
+  // eslint-disable-next-line unicorn/no-for-each -- for...of is banned by no-restricted-syntax in this project
   results.forEach((result) => {
     // eslint-disable-next-line unicorn/no-array-callback-reference
     const filteredIssues = result.issues.filter(isIssueAnError);

--- a/src/rules/no-duplicate-properties.ts
+++ b/src/rules/no-duplicate-properties.ts
@@ -13,7 +13,7 @@ export const ruleType = RuleType.Standard;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const lint = (packageJsonData: PackageJson | any, severity: Severity): LintIssue | null => {
   /**
-   * If we send package json straight to npm-package-json-lint, fallback to empty string.
+   * If we send package JSON straight to npm-package-json-lint, fallback to empty string.
    * Because we already lose information about duplicate properties.
    */
   const source = packageJsonData[sourceSymbol] || '';

--- a/src/utils/getFileList.ts
+++ b/src/utils/getFileList.ts
@@ -43,6 +43,7 @@ export const getFileList = (patterns, cwd) => {
   debug('globFiles');
   debug(globFiles);
 
+  // eslint-disable-next-line unicorn/no-for-each -- for...of is banned by no-restricted-syntax in this project
   globFiles.forEach((globFile) => {
     const filePath = path.resolve(cwd, globFile);
 

--- a/src/utils/isPlainObj.ts
+++ b/src/utils/isPlainObj.ts
@@ -5,9 +5,13 @@ export const isPlainObj = (value: unknown): boolean => {
 
   const prototype = Object.getPrototypeOf(value);
 
+  // These `in` checks must traverse the prototype chain (e.g. to detect Map/Set), so Object.hasOwn()
+  // (own-properties-only) would be a behavior regression here.
   return (
     (prototype === null || prototype === Object.prototype || Object.getPrototypeOf(prototype) === null) &&
+    // eslint-disable-next-line unicorn/no-computed-property-existence-check
     !(Symbol.toStringTag in value) &&
+    // eslint-disable-next-line unicorn/no-computed-property-existence-check
     !(Symbol.iterator in value)
   );
 };

--- a/src/validators/alphabetical-sort.ts
+++ b/src/validators/alphabetical-sort.ts
@@ -28,8 +28,16 @@ export const isInAlphabeticalOrder = (
     validNode: null,
   };
   const nodeKeysOriginal = Object.keys(packageJsonData[nodeName]);
-  // eslint-disable-next-line unicorn/no-array-sort
-  const nodeKeysSorted = Object.keys(packageJsonData[nodeName]).sort();
+  // Explicit compare function that reproduces the default string sort behavior (UTF-16 code unit order).
+  // `a - b` (this rule's suggested simplification) is invalid for string operands (produces NaN).
+  // eslint-disable-next-line unicorn/no-array-sort, unicorn/prefer-simple-sort-comparator
+  const nodeKeysSorted = Object.keys(packageJsonData[nodeName]).sort((a, b) => {
+    if (a < b) {
+      return -1;
+    }
+
+    return a > b ? 1 : 0;
+  });
 
   for (let keyIndex = 0; keyIndex < nodeKeysOriginal.length; keyIndex += increment) {
     if (nodeKeysOriginal[keyIndex] !== nodeKeysSorted[keyIndex]) {

--- a/src/validators/dependency-audit.ts
+++ b/src/validators/dependency-audit.ts
@@ -231,8 +231,6 @@ export const auditDependenciesForValidRangeVersions = (
   config: any,
 ): AuditDependenciesForValidRangeResponse => {
   let onlyValidVersionsDetected = true;
-  const dependenciesWithValidVersionRange = [];
-  const dependenciesWithoutValidVersionRange = [];
 
   if (!packageJsonData.hasOwnProperty(nodeName)) {
     return {
@@ -241,6 +239,9 @@ export const auditDependenciesForValidRangeVersions = (
       dependenciesWithoutValidVersionRange: [],
     };
   }
+
+  const dependenciesWithValidVersionRange = [];
+  const dependenciesWithoutValidVersionRange = [];
 
   // eslint-disable-next-line no-restricted-syntax
   for (const dependencyName in packageJsonData[nodeName]) {
@@ -455,24 +456,24 @@ export const auditDependenciesForNonAbsoluteVersion = (
 const GITHUB_SHORTCUT_URL = /^(github:)?[^/]+\/[^/]+/;
 
 /**
- * Determines whether or not version is a shortcut to github repository
+ * Determines whether or not version is a shortcut to GitHub repository
  * @param version       value of package's version
- * @return {boolean}    True if the version is a shortcut to github repository
+ * @return {boolean}    True if the version is a shortcut to GitHub repository
  */
 const isGithubRepositoryShortcut = (version): boolean => GITHUB_SHORTCUT_URL.test(version);
 
 /**
- * Determines whether or not version is url to archive
+ * Determines whether or not version is URL to archive
  * @param version       value of package's version
- * @return {boolean}    True if the version is url to archive
+ * @return {boolean}    True if the version is URL to archive
  */
 const isArchiveUrl = (version: string): boolean =>
   version.endsWith('.tgz') || version.endsWith('.tar.gz') || version.endsWith('.zip');
 
 /**
- * Determines whether or not version is git repository url
+ * Determines whether or not version is Git repository URL
  * @param version       value of package's version
- * @return {boolean}    True if the version is an git repo url.
+ * @return {boolean}    True if the version is an Git repo URL.
  */
 const isGitRepositoryUrl = (version: string): boolean => {
   if (isArchiveUrl(version)) {
@@ -502,11 +503,11 @@ export interface AuditDependenciesForGitRepositoryVersionResponse {
 }
 
 /**
- * Determines whether or not dependency versions are git repository
+ * Determines whether or not dependency versions are Git repository
  * @param packageJsonData Valid JSON
  * @param nodeName Name of a node in the package.json file
  * @param config Rule configuration
- * @return True if the package has an git repo.
+ * @return True if the package has an Git repo.
  */
 export const auditDependenciesForGitRepositoryVersion = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -550,11 +551,11 @@ export interface AuditDependenciesForArchiveUrlVersionResponse {
 }
 
 /**
- * Determines whether or not dependency versions contains archive url
+ * Determines whether or not dependency versions contains archive URL
  * @param packageJsonData Valid JSON
  * @param nodeName Name of a node in the package.json file
  * @param config Rule configuration
- * @return True if the package contain archive url.
+ * @return True if the package contain archive URL.
  */
 export const auditDependenciesForArchiveUrlVersion = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -598,11 +599,11 @@ export interface AuditDependenciesForFileUrlVersionResponse {
 }
 
 /**
- * Determines whether or not dependency versions contains file url
+ * Determines whether or not dependency versions contains file URL
  * @param packageJsonData Valid JSON
  * @param nodeName Name of a node in the package.json file
  * @param config Rule configuration
- * @return True if the package contain file url.
+ * @return True if the package contain file URL.
  */
 export const auditDependenciesForFileUrlVersion = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/validators/property-order.ts
+++ b/src/validators/property-order.ts
@@ -85,6 +85,7 @@ export const isInPreferredOrder = (
   const fltrdActualNodeList = actualNodeList.filter((property) => preferredNodeOrder.indexOf(property) !== notFound);
   const filteredPreferredOrderMap = new Map();
 
+  // eslint-disable-next-line unicorn/no-for-each -- for...of is banned by no-restricted-syntax in this project
   fltrdPreferredNodeOrder.forEach((property, index) => {
     filteredPreferredOrderMap.set(property, index);
   });

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -21,7 +21,7 @@ export default defineConfig([
       skipNodeModulesBundle: true,
     },
 
-    // This ensures rules stay in dist/rules/ and api/cli stay in dist/
+    // This ensures rules stay in dist/rules/ and API/CLI stay in dist/
     bundle: true,
   },
   {
@@ -42,7 +42,7 @@ export default defineConfig([
       skipNodeModulesBundle: true,
     },
 
-    // This ensures rules stay in dist/rules/ and api/cli stay in dist/
+    // This ensures rules stay in dist/rules/ and API/CLI stay in dist/
     bundle: true,
   },
   {
@@ -64,7 +64,7 @@ export default defineConfig([
       skipNodeModulesBundle: true,
     },
 
-    // This ensures rules stay in dist/rules/ and api/cli stay in dist/
+    // This ensures rules stay in dist/rules/ and API/CLI stay in dist/
     bundle: true,
   },
 ]);


### PR DESCRIPTION
**Description of change**

Bumps `eslint-plugin-unicorn` from 65.0.1 to 66.0.0 (continuing the incremental major-version approach from #1882, to keep each bump's lint fallout small and reviewable).

This version enables/changes several rules that required source changes beyond a version bump:

- `no-top-level-side-effects`: lazily initialize the shared Ajv instance in `ConfigSchema.ts` instead of constructing it at module load time.
- `no-useless-template-literals`: dropped redundant template-literal wrapping around already-string-returning `formatSchemaErrors()` calls.
- `no-for-each`: kept `.forEach()` (with an explanatory disable comment) everywhere the rule's own suggested fix — a `for...of` loop — is banned by this project's existing `no-restricted-syntax` rule.
- `prefer-ternary` / `prefer-minimal-ternary`: simplified an `if`/`else` to a ternary, and collapsed two ternaries that called different `chalk`/`exitCodes` properties into a single computed-property lookup.
- `prefer-unicode-code-point-escapes`: switched the BOM-stripping regex to a `\u{FEFF}` escape.
- `no-declarations-before-early-exit`: moved two array declarations after the early-return branch that never uses them.
- `no-computed-property-existence-check`: kept the `in` operator (with a disable comment) in `isPlainObj` — the suggested `Object.hasOwn()` only checks own properties, not inherited ones, which would break detection of built-ins like `Map`/`Set` that implement `Symbol.iterator` via their prototype.
- `require-array-sort-compare` / `prefer-simple-sort-comparator`: added an explicit string comparator that reproduces the default sort order; kept it (with a disable comment) instead of the second rule's suggested `a - b` rewrite, which is invalid for string operands (produces `NaN`).
- `comment-content`: auto-fixed comment wording (json/api/github/url/git → JSON/API/GitHub/URL/Git).

Verified: build, full lint (0 errors), and full test suite (148/148 suites, 815/815 tests) all pass locally.

**Checklist**

- [x] Unit tests have been added (existing suite passes unchanged; no behavior changes introduced)
- [ ] Specific notes for documentation, if applicable


---
_Generated by [Claude Code](https://claude.ai/code/session_011CQXt16L3t5PKJSQxg9YRz)_