### PR TITLE
build(deps-dev): Bump eslint-plugin-unicorn from 66.0.0 to 67.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "eslint-plugin-import-x": "4.17.1",
         "eslint-plugin-jest": "29.15.5",
         "eslint-plugin-prettier": "5.5.6",
-        "eslint-plugin-unicorn": "66.0.0",
+        "eslint-plugin-unicorn": "67.0.0",
         "globals": "17.7.0",
         "jest": "30.4.2",
         "npm-package-json-lint-config-default": "9.0.1",
@@ -3859,9 +3859,9 @@
       }
     },
     "node_modules/eslint-plugin-unicorn": {
-      "version": "66.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-66.0.0.tgz",
-      "integrity": "sha512-+ywdy8T3foyZ2t3nRBujGa3vfOVMobHIi5iLB0L+fogdVO3EiUJ4BAyIacogWytnweLw3hgT70LQL9KoKTY/kA==",
+      "version": "67.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-67.0.0.tgz",
+      "integrity": "sha512-XEYhNfAFFFYQLq++53iqpgIPFqvjasf5lsUJuCdmd/QvbRfcLbmPTjcTyVEXc5yBudWIg08SSEGgqJtEojk1ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-import-x": "4.17.1",
     "eslint-plugin-jest": "29.15.5",
     "eslint-plugin-prettier": "5.5.6",
-    "eslint-plugin-unicorn": "66.0.0",
+    "eslint-plugin-unicorn": "67.0.0",
     "globals": "17.7.0",
     "jest": "30.4.2",
     "npm-package-json-lint-config-default": "9.0.1",

--- a/src/config/ConfigSchema.ts
+++ b/src/config/ConfigSchema.ts
@@ -1,21 +1,23 @@
 import Ajv from 'ajv';
 import ajvErrors from 'ajv-errors';
 
-let ajvInstance: Ajv | undefined;
-
 /**
  * Lazily creates (and memoizes) the shared Ajv instance.
  *
  * @returns {Ajv} The shared Ajv instance.
  */
-const getAjv = (): Ajv => {
-  if (!ajvInstance) {
-    ajvInstance = new Ajv({allErrors: true});
-    ajvErrors(ajvInstance);
-  }
+const getAjv = ((): (() => Ajv) => {
+  let ajvInstance: Ajv | undefined;
 
-  return ajvInstance;
-};
+  return (): Ajv => {
+    if (!ajvInstance) {
+      ajvInstance = new Ajv({allErrors: true});
+      ajvErrors(ajvInstance);
+    }
+
+    return ajvInstance;
+  };
+})();
 
 /**
  * Formats an array of schema validation errors.

--- a/src/console-reporter.ts
+++ b/src/console-reporter.ts
@@ -22,17 +22,17 @@ const printResultSetIssues = (issues: LintIssue[]): void => {
  * Print results for an individual package.json file linting
  *
  * @param resultSet Result object from a given file's lint result
- * @param quiet True suppress warnings, false show warnings
+ * @param isQuiet True suppress warnings, false show warnings
  * @internal
  */
-const printIndividualResultSet = (resultSet, quiet: boolean): void => {
+const printIndividualResultSet = (resultSet, isQuiet: boolean): void => {
   const {filePath, issues, ignored, errorCount, warningCount} = resultSet;
 
   if (ignored) {
     console.log('');
 
     console.log(`${chalk.yellow.underline(filePath)} - ignored`);
-  } else if (errorCount > zeroIssues || (!quiet && warningCount > zeroIssues)) {
+  } else if (errorCount > zeroIssues || (!isQuiet && warningCount > zeroIssues)) {
     console.log('');
 
     console.log(chalk.underline(filePath));
@@ -44,7 +44,7 @@ const printIndividualResultSet = (resultSet, quiet: boolean): void => {
 
     console.log(chalk.red.bold(errorCountMessage));
 
-    if (!quiet) {
+    if (!isQuiet) {
       console.log(chalk.yellow.bold(warningCountMessage));
     }
   }
@@ -54,10 +54,10 @@ const printIndividualResultSet = (resultSet, quiet: boolean): void => {
  * Prints the overall total counts section
  *
  * @param linterOutput Full results from linting. Includes an array of results and overall counts
- * @param quiet True suppress warnings, false show warnings
+ * @param isQuiet True suppress warnings, false show warnings
  * @internal
  */
-const printTotals = (linterOutput, quiet: boolean): void => {
+const printTotals = (linterOutput, isQuiet: boolean): void => {
   const {errorCount, warningCount, ignoreCount} = linterOutput;
 
   if (errorCount > zeroIssues || warningCount > zeroIssues) {
@@ -69,7 +69,7 @@ const printTotals = (linterOutput, quiet: boolean): void => {
     console.log(chalk.underline('Totals'));
     console.log(chalk.red.bold(errorCountMessage));
 
-    if (!quiet) {
+    if (!isQuiet) {
       console.log(chalk.yellow.bold(warningCountMessage));
       console.log(chalk.yellow.bold(ignoreCountMessage));
     }
@@ -80,16 +80,16 @@ const printTotals = (linterOutput, quiet: boolean): void => {
  * Print results to console
  *
  * @param linterOutput An array of LintIssues
- * @param quiet Flag indicating whether to print warnings.
+ * @param isQuiet Flag indicating whether to print warnings.
  * @internal
  */
-export const write = (linterOutput, quiet: boolean): void => {
+export const write = (linterOutput, isQuiet: boolean): void => {
   // eslint-disable-next-line unicorn/no-for-each -- for...of is banned by no-restricted-syntax in this project
   linterOutput.results.forEach((result) => {
-    printIndividualResultSet(result, quiet);
+    printIndividualResultSet(result, isQuiet);
   });
 
   if (linterOutput.results.length > oneFile) {
-    printTotals(linterOutput, quiet);
+    printTotals(linterOutput, isQuiet);
   }
 };

--- a/src/npm-package-json-lint.ts
+++ b/src/npm-package-json-lint.ts
@@ -30,7 +30,7 @@ const isIssueAnError = (issue: LintIssue): boolean => issue.severity === Severit
 const isPackageJsonObjectValid = (packageJsonObject: PackageJson | any): boolean => isPlainObj(packageJsonObject);
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const areRequiredOptionsValid = (packageJsonObject: PackageJson | any, patterns: string[]): boolean =>
+const isRequiredOptionsValid = (packageJsonObject: PackageJson | any, patterns: string[]): boolean =>
   (!patterns && !isPackageJsonObjectValid(packageJsonObject)) ||
   (patterns && (packageJsonObject || isPackageJsonObjectValid(packageJsonObject)));
 
@@ -148,7 +148,7 @@ export class NpmPackageJsonLint {
   lint(): OverallLintingResult {
     debug('Starting lint');
 
-    if (areRequiredOptionsValid(this.packageJsonObject, this.patterns)) {
+    if (isRequiredOptionsValid(this.packageJsonObject, this.patterns)) {
       throw new Error(
         'You must pass npm-package-json-lint a `patterns` glob or a `packageJsonObject` string, though not both.',
       );

--- a/src/rules/valid-values-name-scope.ts
+++ b/src/rules/valid-values-name-scope.ts
@@ -3,7 +3,7 @@ import {LintIssue} from '../lint-issue';
 import {LintResult} from '../types/lint-result';
 import {RuleType} from '../types/rule-type';
 import {Severity} from '../types/severity';
-import {matchValidValue} from '../validators/valid-values';
+import {isMatchingValidValue} from '../validators/valid-values';
 
 const lintId = 'valid-values-name-scope';
 const nodeName = 'name';
@@ -28,7 +28,7 @@ export const lint = (
 ): LintResult => {
   const validRegexes = validValues.map((scope) => new RegExp(`^${scope}/`));
 
-  if (!matchValidValue(packageJsonData, nodeName, packageJsonData[nodeName], validRegexes)) {
+  if (!isMatchingValidValue(packageJsonData, nodeName, packageJsonData[nodeName], validRegexes)) {
     return new LintIssue(
       lintId,
       severity,

--- a/src/validators/dependency-audit.ts
+++ b/src/validators/dependency-audit.ts
@@ -202,7 +202,7 @@ export const auditDependenciesWithMajorVersionOfZero = (
  * @param  {String}   rangeSpecifier      A version range specifier
  * @return {Boolean}                      True if the version starts with the range, false if it doesn't.
  */
-export const doesVersionStartWithRange = (dependencyVersion: string, rangeSpecifier: string): boolean => {
+export const isVersionStartingWithRange = (dependencyVersion: string, rangeSpecifier: string): boolean => {
   const firstCharOfStr = 0;
 
   return dependencyVersion.startsWith(rangeSpecifier, firstCharOfStr);
@@ -230,11 +230,11 @@ export const auditDependenciesForValidRangeVersions = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   config: any,
 ): AuditDependenciesForValidRangeResponse => {
-  let onlyValidVersionsDetected = true;
+  let isOnlyValidVersionsDetected = true;
 
   if (!packageJsonData.hasOwnProperty(nodeName)) {
     return {
-      onlyValidVersionsDetected,
+      onlyValidVersionsDetected: isOnlyValidVersionsDetected,
       dependenciesWithValidVersionRange: [],
       dependenciesWithoutValidVersionRange: [],
     };
@@ -252,16 +252,16 @@ export const auditDependenciesForValidRangeVersions = (
 
     const dependencyVersion = packageJsonData[nodeName][dependencyName];
 
-    if (doesVersionStartWithRange(dependencyVersion, rangeSpecifier)) {
+    if (isVersionStartingWithRange(dependencyVersion, rangeSpecifier)) {
       dependenciesWithValidVersionRange.push(dependencyName);
     } else {
-      onlyValidVersionsDetected = false;
+      isOnlyValidVersionsDetected = false;
       dependenciesWithoutValidVersionRange.push(dependencyName);
     }
   }
 
   return {
-    onlyValidVersionsDetected,
+    onlyValidVersionsDetected: isOnlyValidVersionsDetected,
     dependenciesWithValidVersionRange,
     dependenciesWithoutValidVersionRange,
   };
@@ -310,7 +310,7 @@ export const auditDependenciesForInvalidRange = (
 
     const dependencyVersion = packageJsonData[nodeName][dependencyName];
 
-    if (doesVersionStartWithRange(dependencyVersion, rangeSpecifier)) {
+    if (isVersionStartingWithRange(dependencyVersion, rangeSpecifier)) {
       hasInvalidRangeVersions = true;
       dependenciesWithInvalidVersionRange.push(dependencyName);
     } else {
@@ -347,7 +347,7 @@ const auditAbsoluteVersions = (
 ): AbsoluteVersionCheckerResult => {
   const notFound = -1;
   const firstCharOfStr = 0;
-  let onlyAbsoluteVersionDetected = true;
+  let isOnlyAbsoluteVersionDetected = true;
   let dependenciesChecked = 0;
   const dependenciesWithAbsoluteVersion = [];
   const dependenciesWithoutAbsoluteVersion = [];
@@ -368,7 +368,7 @@ const auditAbsoluteVersions = (
       dependencyVersion.startsWith('<', firstCharOfStr) ||
       dependencyVersion.indexOf('*') !== notFound
     ) {
-      onlyAbsoluteVersionDetected = false;
+      isOnlyAbsoluteVersionDetected = false;
       dependenciesWithoutAbsoluteVersion.push(dependencyName);
     } else {
       dependenciesWithAbsoluteVersion.push(dependencyName);
@@ -378,7 +378,7 @@ const auditAbsoluteVersions = (
   }
 
   return {
-    onlyAbsoluteVersionDetected,
+    onlyAbsoluteVersionDetected: isOnlyAbsoluteVersionDetected,
     dependenciesChecked,
     dependenciesWithAbsoluteVersion,
     dependenciesWithoutAbsoluteVersion,
@@ -483,17 +483,17 @@ const isGitRepositoryUrl = (version: string): boolean => {
   // based on https://github.com/npm/hosted-git-info
   const protocols = new Set(['git@', 'git://', 'git+https://', 'git+ssh://', 'http://', 'https://']);
 
-  let match = false;
+  let isMatch = false;
 
   // eslint-disable-next-line no-restricted-syntax
   for (const protocol of protocols) {
     if (version.startsWith(protocol)) {
-      match = true;
+      isMatch = true;
       break;
     }
   }
 
-  return match;
+  return isMatch;
 };
 
 export interface AuditDependenciesForGitRepositoryVersionResponse {

--- a/src/validators/property.ts
+++ b/src/validators/property.ts
@@ -8,7 +8,8 @@ import type {PackageJson} from 'type-fest';
  * @param nodeName Name of a node in the package.json file
  * @return True if the node exists. False if it is not.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// `exists` is used across 29 files; renaming risks colliding with unrelated string literals (e.g. no-repeated-dependencies.ts).
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, unicorn/consistent-boolean-name
 export const exists = (packageJsonData: PackageJson | any, nodeName: string): boolean =>
   packageJsonData.hasOwnProperty(nodeName);
 

--- a/src/validators/valid-values.ts
+++ b/src/validators/valid-values.ts
@@ -32,7 +32,7 @@ export const isValidValue = <T>(
  * @param validRegexes Array of regex to validate against
  * @return True if the node matches one of the valid regexes or is missing. False if it is not.
  */
-export const matchValidValue = (
+export const isMatchingValidValue = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   packageJsonData: PackageJson | any,
   nodeName: string,

--- a/test/unit/utils/getNameError.test.ts
+++ b/test/unit/utils/getNameError.test.ts
@@ -2,19 +2,19 @@ import {getNameError} from '../../../src/utils/getNameError';
 
 const genericErrorMessage = 'name invalid';
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const getResults = (includeErrors = true, includeWarnings = true) => {
+const getResults = (shouldIncludeErrors = true, shouldIncludeWarnings = true) => {
   const results = {
     validForNewPackages: false,
-    validForOldPackages: !includeErrors,
+    validForOldPackages: !shouldIncludeErrors,
     warnings: ['first warning', 'second warning'],
     errors: ['first error', 'second error'],
   };
 
-  if (!includeErrors) {
+  if (!shouldIncludeErrors) {
     delete results.errors;
   }
 
-  if (!includeWarnings) {
+  if (!shouldIncludeWarnings) {
     delete results.warnings;
   }
 

--- a/test/unit/validators/dependency-audit.test.ts
+++ b/test/unit/validators/dependency-audit.test.ts
@@ -718,11 +718,11 @@ describe('dependency-audit Unit Tests', () => {
     });
   });
 
-  describe('doesVersionStartWithRange method', () => {
+  describe('isVersionStartingWithRange method', () => {
     describe('when dependencyVersion begins with range specifier', () => {
       test('true should be returned', () => {
         const dependencyVersion = '^1.0.0';
-        const response = dependencyAudit.doesVersionStartWithRange(dependencyVersion, '^');
+        const response = dependencyAudit.isVersionStartingWithRange(dependencyVersion, '^');
 
         expect(response).toBe(true);
       });
@@ -731,7 +731,7 @@ describe('dependency-audit Unit Tests', () => {
     describe('when dependencyVersion does not begin with range specifier', () => {
       test('false should be returned', () => {
         const dependencyVersion = '^1.0.0';
-        const response = dependencyAudit.doesVersionStartWithRange(dependencyVersion, '~');
+        const response = dependencyAudit.isVersionStartingWithRange(dependencyVersion, '~');
 
         expect(response).toBe(false);
       });

--- a/test/unit/validators/valid-values.test.ts
+++ b/test/unit/validators/valid-values.test.ts
@@ -59,7 +59,7 @@ describe('value-values Unit Tests', () => {
     });
   });
 
-  describe('matchValidValue method', () => {
+  describe('isMatchingValidValue method', () => {
     const packageJson = {
       name: '@lerna/publish',
     };
@@ -67,7 +67,7 @@ describe('value-values Unit Tests', () => {
     describe('when the node does not exist in the package.json file', () => {
       test('true should be returned', () => {
         const validRegexes = [/^@babel\//, /run$/, /\d+/];
-        const response = validValuesObj.matchValidValue(packageJson, 'names', packageJson.name, validRegexes);
+        const response = validValuesObj.isMatchingValidValue(packageJson, 'names', packageJson.name, validRegexes);
 
         expect(response).toBe(true);
       });
@@ -76,7 +76,7 @@ describe('value-values Unit Tests', () => {
     describe('when the node exists in the package.json file and the value matches', () => {
       test('true should be returned', () => {
         const validRegexes = [/^@lerna\//, /^@babel\//, /run$/, /\d+/];
-        const response = validValuesObj.matchValidValue(packageJson, 'name', packageJson.name, validRegexes);
+        const response = validValuesObj.isMatchingValidValue(packageJson, 'name', packageJson.name, validRegexes);
 
         expect(response).toBe(true);
       });
@@ -85,7 +85,7 @@ describe('value-values Unit Tests', () => {
     describe('when the node exists in the package.json file, but the value does not match', () => {
       test('false should be returned', () => {
         const validRegexes = [/^@babel\//, /run$/, /\d+/];
-        const response = validValuesObj.matchValidValue(packageJson, 'name', packageJson.name, validRegexes);
+        const response = validValuesObj.isMatchingValidValue(packageJson, 'name', packageJson.name, validRegexes);
 
         expect(response).toBe(false);
       });


### PR DESCRIPTION
**Description of change**

Bumps `eslint-plugin-unicorn` from 66.0.0 to 67.0.0 (continuing the incremental major-version approach from #1882/#1891, to keep each bump's lint fallout small and reviewable).

This version enables/changes two rules that required source changes beyond a version bump:

- `no-top-level-assignment-in-function`: wrapped the shared Ajv instance and its memoized variable in an IIFE closure in `ConfigSchema.ts`, so the mutable state is no longer a top-level variable. It was previously writing to a top-level `let` from inside a function — the exact pattern used to satisfy `no-top-level-side-effects` in the 66.0.0 bump, which this new rule now separately forbids.
- `consistent-boolean-name`: renamed boolean-typed locals/functions to start with an approved prefix (`is`/`has`/`can`/`should`/`was`/`did`/`will`):
  - `console-reporter.ts`: `quiet` → `isQuiet` (positional param, no external call sites affected)
  - `npm-package-json-lint.ts`: `areRequiredOptionsValid` → `isRequiredOptionsValid` (local, not exported)
  - `dependency-audit.ts`: `doesVersionStartWithRange` → `isVersionStartingWithRange` (exported; updated both internal call sites and the test file); two `let` locals renamed to `isOnlyValidVersionsDetected` / `isOnlyAbsoluteVersionDetected` while keeping their *returned object keys* unchanged, since those keys are part of a response shape consumed by 5 other rule files and the test suite; local `match` → `isMatch`
  - `valid-values.ts`: `matchValidValue` → `isMatchingValidValue` (small, contained blast radius: one rule file + one test file, both updated)
  - `test/unit/utils/getNameError.test.ts`: `includeErrors`/`includeWarnings` → `shouldIncludeErrors`/`shouldIncludeWarnings` (local test helper params)
  - `property.ts`: kept `exists` and suppressed the rule instead of renaming — it's imported in 29 files, and at least one (`no-repeated-dependencies.ts`) has the literal word "exists" inside a user-facing error message, making a safe mechanical rename non-trivial for what is a purely cosmetic rule.

Verified: build, full lint (0 errors), and full test suite (148/148 suites, 815/815 tests) all pass locally.

**Checklist**

- [x] Unit tests have been added (existing suite passes unchanged; no behavior changes introduced)
- [ ] Specific notes for documentation, if applicable


---
_Generated by [Claude Code](https://claude.ai/code/session_011CQXt16L3t5PKJSQxg9YRz)_