### PR TITLE
build(deps-dev): Bump eslint-plugin-unicorn from 67.0.0 to 68.0.0

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,10 @@ export default [
       'no-prototype-builtins': 'off',
       'unicorn/filename-case': 'off',
       'unicorn/prefer-module': 'off',
+      // This rule's abbreviation dictionary doesn't fit this codebase's domain vocabulary -- e.g. it wants
+      // `devDependencies` renamed to `developmentDependencies`, which is wrong since that's a literal npm
+      // package.json field name, not a generic abbreviation to expand.
+      'unicorn/name-replacements': 'off',
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "eslint-plugin-import-x": "4.17.1",
         "eslint-plugin-jest": "29.15.5",
         "eslint-plugin-prettier": "5.5.6",
-        "eslint-plugin-unicorn": "67.0.0",
+        "eslint-plugin-unicorn": "68.0.0",
         "globals": "17.7.0",
         "jest": "30.4.2",
         "npm-package-json-lint-config-default": "9.0.1",
@@ -3859,9 +3859,9 @@
       }
     },
     "node_modules/eslint-plugin-unicorn": {
-      "version": "67.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-67.0.0.tgz",
-      "integrity": "sha512-XEYhNfAFFFYQLq++53iqpgIPFqvjasf5lsUJuCdmd/QvbRfcLbmPTjcTyVEXc5yBudWIg08SSEGgqJtEojk1ug==",
+      "version": "68.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-68.0.0.tgz",
+      "integrity": "sha512-mHYWvX948Q4H3bGc39bsNMxD/leOuNI+Iws9NVsoSz5VA7EGP86wnz7mZ/SPSvRhefT8L4hd8DHfDuGC+lIoCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-import-x": "4.17.1",
     "eslint-plugin-jest": "29.15.5",
     "eslint-plugin-prettier": "5.5.6",
-    "eslint-plugin-unicorn": "67.0.0",
+    "eslint-plugin-unicorn": "68.0.0",
     "globals": "17.7.0",
     "jest": "30.4.2",
     "npm-package-json-lint-config-default": "9.0.1",

--- a/src/linter/linter.ts
+++ b/src/linter/linter.ts
@@ -219,10 +219,12 @@ export const executeOnPackageJsonObject = (options: ExecuteOnPackageJsonObjectOp
   const resolvedFilename = path.isAbsolute(filenameDefaulted) ? filenameDefaulted : path.resolve(cwd, filenameDefaulted);
   const relativeFilePath = path.relative(cwd, resolvedFilename);
 
+  let result;
+
   if (ignorer.ignores(relativeFilePath)) {
     debug(`Ignored: ${relativeFilePath}`);
 
-    const result = createResultObject({
+    result = createResultObject({
       cwd,
       fileName: resolvedFilename,
       ignored: true,
@@ -230,17 +232,15 @@ export const executeOnPackageJsonObject = (options: ExecuteOnPackageJsonObjectOp
       errorCount: 0,
       warningCount: 0,
     });
-
-    results.push(result);
   } else {
     debug(`Getting config for ${resolvedFilename}`);
     const config = configHelper.getConfigForFile(resolvedFilename);
 
     debug(`Config fetched for ${resolvedFilename}`);
-    const result = processPackageJsonObject(cwd, packageJsonObject, config, resolvedFilename, rules);
-
-    results.push(result);
+    result = processPackageJsonObject(cwd, packageJsonObject, config, resolvedFilename, rules);
   }
+
+  results.push(result);
 
   debug('Aggregating overall counts');
   const stats = aggregateOverallCounts(results);

--- a/src/rules/scripts-type.ts
+++ b/src/rules/scripts-type.ts
@@ -22,12 +22,15 @@ export const lint = (packageJsonData: PackageJson | any, severity: Severity): Li
 
     // eslint-disable-next-line no-restricted-syntax
     for (const key in scripts) {
-      if (scripts.hasOwnProperty(key)) {
-        const value = scripts[key];
+      if (!scripts.hasOwnProperty(key)) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
 
-        if (typeof value !== 'string') {
-          return new LintIssue(lintId, severity, nodeName, `script, ${key}, in the "scripts" property is not a string.`);
-        }
+      const value = scripts[key];
+
+      if (typeof value !== 'string') {
+        return new LintIssue(lintId, severity, nodeName, `script, ${key}, in the "scripts" property is not a string.`);
       }
     }
   }

--- a/src/validators/alphabetical-sort.ts
+++ b/src/validators/alphabetical-sort.ts
@@ -40,14 +40,17 @@ export const isInAlphabeticalOrder = (
   });
 
   for (let keyIndex = 0; keyIndex < nodeKeysOriginal.length; keyIndex += increment) {
-    if (nodeKeysOriginal[keyIndex] !== nodeKeysSorted[keyIndex]) {
-      isValid = false;
-      data = {
-        invalidNode: nodeKeysOriginal[keyIndex],
-        validNode: nodeKeysSorted[keyIndex],
-      };
-      break;
+    if (nodeKeysOriginal[keyIndex] === nodeKeysSorted[keyIndex]) {
+      // eslint-disable-next-line no-continue
+      continue;
     }
+
+    isValid = false;
+    data = {
+      invalidNode: nodeKeysOriginal[keyIndex],
+      validNode: nodeKeysSorted[keyIndex],
+    };
+    break;
   }
 
   return {

--- a/src/validators/dependency-audit.ts
+++ b/src/validators/dependency-audit.ts
@@ -119,15 +119,18 @@ export const auditDependenciesWithRestrictedPrereleaseVersion = (
 
   // eslint-disable-next-line no-restricted-syntax
   for (const dependencyName in packageJsonData[nodeName]) {
-    if (depsToCheckFor.includes(dependencyName)) {
-      const dependencyVersion = packageJsonData[nodeName][dependencyName];
+    if (!depsToCheckFor.includes(dependencyName)) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
 
-      if (dependencyVersion.includes('-beta') || dependencyVersion.includes('-rc')) {
-        hasDependencyWithRestrictedPrereleaseVersion = true;
-        dependenciesWithRestrictedPrereleaseVersion.push(dependencyName);
-      } else {
-        dependenciesWithoutRestrictedPrereleaseVersion.push(dependencyName);
-      }
+    const dependencyVersion = packageJsonData[nodeName][dependencyName];
+
+    if (dependencyVersion.includes('-beta') || dependencyVersion.includes('-rc')) {
+      hasDependencyWithRestrictedPrereleaseVersion = true;
+      dependenciesWithRestrictedPrereleaseVersion.push(dependencyName);
+    } else {
+      dependenciesWithoutRestrictedPrereleaseVersion.push(dependencyName);
     }
   }
 
@@ -487,10 +490,13 @@ const isGitRepositoryUrl = (version: string): boolean => {
 
   // eslint-disable-next-line no-restricted-syntax
   for (const protocol of protocols) {
-    if (version.startsWith(protocol)) {
-      isMatch = true;
-      break;
+    if (!version.startsWith(protocol)) {
+      // eslint-disable-next-line no-continue
+      continue;
     }
+
+    isMatch = true;
+    break;
   }
 
   return isMatch;


### PR DESCRIPTION
**Description of change**

Bumps `eslint-plugin-unicorn` from 67.0.0 to 68.0.0 (continuing the incremental major-version approach from #1882/#1891/#1892, to keep each bump's lint fallout small and reviewable).

**`unicorn/name-replacements` disabled.** This bump enables that rule, which flagged 126 violations across 70 files — 40 of them file renames (e.g. `configuration.ts` → `config.ts`, `require-repository.test.ts` → `require-repo.test.ts`), plus renames of widely-used exported functions (`isPlainObj` → `isPlainObject`, `auditDependenciesForGitRepositoryVersion` → `auditDependenciesForGitRepoVersion`). It also wants `devDependencies` renamed to `developmentDependencies` — objectively wrong here, since that's a literal npm `package.json` field name this tool operates on, not a generic abbreviation to expand. Given the scope and the incorrect suggestions mixed in, I disabled the rule in `eslint.config.mjs` (alongside the existing `filename-case`/`prefer-module` overrides) rather than force a sweeping, partly-wrong rewrite across most of the codebase.

**Fixes for the remaining new/changed rules:**
- `prefer-continue`: converted 4 loop bodies wrapped in an `if` into early `continue`s, adding the `no-continue` disable-comment pattern already used elsewhere in this codebase (`for...of`/`for...in` and bare `continue` are otherwise banned here by `no-restricted-syntax`/`no-continue`).
- `prefer-hoisting-branch-code`: hoisted a duplicated `results.push(result)` call in `linter.ts` out of both branches of an `if`/`else` into a single call after it.

Verified: build, full lint (0 errors), and full test suite (148/148 suites, 815/815 tests) all pass locally.

**Checklist**

- [x] Unit tests have been added (existing suite passes unchanged; no behavior changes introduced)
- [ ] Specific notes for documentation, if applicable


---
_Generated by [Claude Code](https://claude.ai/code/session_011CQXt16L3t5PKJSQxg9YRz)_