### PR TITLE
build(deps-dev): Bump eslint-plugin-unicorn from 68.0.0 to 69.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "eslint-plugin-import-x": "4.17.1",
         "eslint-plugin-jest": "29.15.5",
         "eslint-plugin-prettier": "5.5.6",
-        "eslint-plugin-unicorn": "68.0.0",
+        "eslint-plugin-unicorn": "69.0.0",
         "globals": "17.7.0",
         "jest": "30.4.2",
         "npm-package-json-lint-config-default": "9.0.1",
@@ -3859,9 +3859,9 @@
       }
     },
     "node_modules/eslint-plugin-unicorn": {
-      "version": "68.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-68.0.0.tgz",
-      "integrity": "sha512-mHYWvX948Q4H3bGc39bsNMxD/leOuNI+Iws9NVsoSz5VA7EGP86wnz7mZ/SPSvRhefT8L4hd8DHfDuGC+lIoCQ==",
+      "version": "69.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-69.0.0.tgz",
+      "integrity": "sha512-ZN/KtHr9hQ6AOByANSNJpsDbo/+Nn+EyQ6blK4w+dcmS/xpYkqLLfrUc+NA/wOK6vF5uEUvhn8my5B/3sruB9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-import-x": "4.17.1",
     "eslint-plugin-jest": "29.15.5",
     "eslint-plugin-prettier": "5.5.6",
-    "eslint-plugin-unicorn": "68.0.0",
+    "eslint-plugin-unicorn": "69.0.0",
     "globals": "17.7.0",
     "jest": "30.4.2",
     "npm-package-json-lint-config-default": "9.0.1",


### PR DESCRIPTION
**Description of change**

Bumps `eslint-plugin-unicorn` from 68.0.0 to 69.0.0 (continuing the incremental major-version approach from #1882/#1891/#1892/#1893, to keep each bump's lint fallout small and reviewable).

No source changes required — lint was already clean after the version bump.

Verified: build, full lint (0 errors), and full test suite (148/148 suites, 815/815 tests) all pass locally.

**Checklist**

- [x] Unit tests have been added (existing suite passes unchanged; no behavior changes introduced)
- [ ] Specific notes for documentation, if applicable


---
_Generated by [Claude Code](https://claude.ai/code/session_011CQXt16L3t5PKJSQxg9YRz)_