### PR TITLE
build(deps-dev): Bump eslint-plugin-unicorn from 69.0.0 to 70.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "eslint-plugin-import-x": "4.17.1",
         "eslint-plugin-jest": "29.15.5",
         "eslint-plugin-prettier": "5.5.6",
-        "eslint-plugin-unicorn": "69.0.0",
+        "eslint-plugin-unicorn": "70.0.0",
         "globals": "17.7.0",
         "jest": "30.4.2",
         "npm-package-json-lint-config-default": "9.0.1",
@@ -3859,9 +3859,9 @@
       }
     },
     "node_modules/eslint-plugin-unicorn": {
-      "version": "69.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-69.0.0.tgz",
-      "integrity": "sha512-ZN/KtHr9hQ6AOByANSNJpsDbo/+Nn+EyQ6blK4w+dcmS/xpYkqLLfrUc+NA/wOK6vF5uEUvhn8my5B/3sruB9g==",
+      "version": "70.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-70.0.0.tgz",
+      "integrity": "sha512-uAF9xMcVvvhTfvusCgogJ1wh4To3q2KhVMw3i1Apf/ILTbxsCjscvraAZACsEurb7no2fdXblD3whcbVnjw5zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-import-x": "4.17.1",
     "eslint-plugin-jest": "29.15.5",
     "eslint-plugin-prettier": "5.5.6",
-    "eslint-plugin-unicorn": "69.0.0",
+    "eslint-plugin-unicorn": "70.0.0",
     "globals": "17.7.0",
     "jest": "30.4.2",
     "npm-package-json-lint-config-default": "9.0.1",

--- a/src/rules/prefer-alphabetical-bundledDependencies.ts
+++ b/src/rules/prefer-alphabetical-bundledDependencies.ts
@@ -1,5 +1,5 @@
 import type {PackageJson} from 'type-fest';
-import {isInAlphabeticalOrder} from '../validators/alphabetical-sort';
+import {checkAlphabeticalOrder} from '../validators/alphabetical-sort';
 import {exists} from '../validators/property';
 import {LintIssue} from '../lint-issue';
 import {RuleType} from '../types/rule-type';
@@ -17,7 +17,7 @@ export const lint = (packageJsonData: PackageJson | any, severity: Severity): Li
     return null;
   }
 
-  const result = isInAlphabeticalOrder(packageJsonData, nodeName);
+  const result = checkAlphabeticalOrder(packageJsonData, nodeName);
 
   if (!result.status) {
     return new LintIssue(

--- a/src/rules/prefer-alphabetical-dependencies.ts
+++ b/src/rules/prefer-alphabetical-dependencies.ts
@@ -1,5 +1,5 @@
 import type {PackageJson} from 'type-fest';
-import {isInAlphabeticalOrder} from '../validators/alphabetical-sort';
+import {checkAlphabeticalOrder} from '../validators/alphabetical-sort';
 import {exists} from '../validators/property';
 import {LintIssue} from '../lint-issue';
 import {RuleType} from '../types/rule-type';
@@ -17,7 +17,7 @@ export const lint = (packageJsonData: PackageJson | any, severity: Severity): Li
     return null;
   }
 
-  const result = isInAlphabeticalOrder(packageJsonData, nodeName);
+  const result = checkAlphabeticalOrder(packageJsonData, nodeName);
 
   if (!result.status) {
     return new LintIssue(

--- a/src/rules/prefer-alphabetical-devDependencies.ts
+++ b/src/rules/prefer-alphabetical-devDependencies.ts
@@ -1,5 +1,5 @@
 import type {PackageJson} from 'type-fest';
-import {isInAlphabeticalOrder} from '../validators/alphabetical-sort';
+import {checkAlphabeticalOrder} from '../validators/alphabetical-sort';
 import {exists} from '../validators/property';
 import {LintIssue} from '../lint-issue';
 import {RuleType} from '../types/rule-type';
@@ -17,7 +17,7 @@ export const lint = (packageJsonData: PackageJson | any, severity: Severity): Li
     return null;
   }
 
-  const result = isInAlphabeticalOrder(packageJsonData, nodeName);
+  const result = checkAlphabeticalOrder(packageJsonData, nodeName);
 
   if (!result.status) {
     return new LintIssue(

--- a/src/rules/prefer-alphabetical-optionalDependencies.ts
+++ b/src/rules/prefer-alphabetical-optionalDependencies.ts
@@ -1,5 +1,5 @@
 import type {PackageJson} from 'type-fest';
-import {isInAlphabeticalOrder} from '../validators/alphabetical-sort';
+import {checkAlphabeticalOrder} from '../validators/alphabetical-sort';
 import {exists} from '../validators/property';
 import {LintIssue} from '../lint-issue';
 import {RuleType} from '../types/rule-type';
@@ -17,7 +17,7 @@ export const lint = (packageJsonData: PackageJson | any, severity: Severity): Li
     return null;
   }
 
-  const result = isInAlphabeticalOrder(packageJsonData, nodeName);
+  const result = checkAlphabeticalOrder(packageJsonData, nodeName);
 
   if (!result.status) {
     return new LintIssue(

--- a/src/rules/prefer-alphabetical-peerDependencies.ts
+++ b/src/rules/prefer-alphabetical-peerDependencies.ts
@@ -1,5 +1,5 @@
 import type {PackageJson} from 'type-fest';
-import {isInAlphabeticalOrder} from '../validators/alphabetical-sort';
+import {checkAlphabeticalOrder} from '../validators/alphabetical-sort';
 import {exists} from '../validators/property';
 import {LintIssue} from '../lint-issue';
 import {RuleType} from '../types/rule-type';
@@ -17,7 +17,7 @@ export const lint = (packageJsonData: PackageJson | any, severity: Severity): Li
     return null;
   }
 
-  const result = isInAlphabeticalOrder(packageJsonData, nodeName);
+  const result = checkAlphabeticalOrder(packageJsonData, nodeName);
 
   if (!result.status) {
     return new LintIssue(

--- a/src/rules/prefer-alphabetical-scripts.ts
+++ b/src/rules/prefer-alphabetical-scripts.ts
@@ -1,5 +1,5 @@
 import type {PackageJson} from 'type-fest';
-import {isInAlphabeticalOrder} from '../validators/alphabetical-sort';
+import {checkAlphabeticalOrder} from '../validators/alphabetical-sort';
 import {exists} from '../validators/property';
 import {LintIssue} from '../lint-issue';
 import {RuleType} from '../types/rule-type';
@@ -17,7 +17,7 @@ export const lint = (packageJsonData: PackageJson | any, severity: Severity): Li
     return null;
   }
 
-  const result = isInAlphabeticalOrder(packageJsonData, nodeName);
+  const result = checkAlphabeticalOrder(packageJsonData, nodeName);
 
   if (!result.status) {
     return new LintIssue(

--- a/src/rules/prefer-property-order.ts
+++ b/src/rules/prefer-property-order.ts
@@ -1,5 +1,5 @@
 import type {PackageJson} from 'type-fest';
-import {isInPreferredOrder} from '../validators/property-order';
+import {checkPreferredOrder} from '../validators/property-order';
 import {LintIssue} from '../lint-issue';
 import {RuleType} from '../types/rule-type';
 import {Severity} from '../types/severity';
@@ -18,7 +18,7 @@ export const lint = (
   severity: Severity,
   preferredOrder: string[],
 ): LintIssue | null => {
-  const result = isInPreferredOrder(packageJsonData, preferredOrder);
+  const result = checkPreferredOrder(packageJsonData, preferredOrder);
 
   if (!result.status) {
     return new LintIssue(lintId, severity, nodeName, `${message} ${result.msg}`);

--- a/src/validators/alphabetical-sort.ts
+++ b/src/validators/alphabetical-sort.ts
@@ -2,7 +2,7 @@ import type {PackageJson} from 'type-fest';
 
 const increment = 1;
 
-export interface IsInAlphabeticalOrderResult {
+export interface AlphabeticalOrderResult {
   status: boolean;
   data: {
     invalidNode: string | null;
@@ -17,11 +17,11 @@ export interface IsInAlphabeticalOrderResult {
  * @param nodeName Name of a node in the package.json file
  * @return Object containing the status and the dependencies that are out of order, if applicable
  */
-export const isInAlphabeticalOrder = (
+export const checkAlphabeticalOrder = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   packageJsonData: PackageJson | any,
   nodeName: string,
-): IsInAlphabeticalOrderResult => {
+): AlphabeticalOrderResult => {
   let isValid = true;
   let data = {
     invalidNode: null,

--- a/src/validators/property-order.ts
+++ b/src/validators/property-order.ts
@@ -59,7 +59,7 @@ const defaultPreferredNodeOrder = [
   'workspaces',
 ];
 
-export interface IsInPreferredOrderResult {
+export interface PreferredOrderResult {
   status: boolean;
   msg: string | null;
 }
@@ -71,11 +71,11 @@ export interface IsInPreferredOrderResult {
  * @param userPreferredNodeOrder Preferred order of nodes
  * @return Object containing the status and the node that is out of order, if applicable
  */
-export const isInPreferredOrder = (
+export const checkPreferredOrder = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   packageJsonData: PackageJson | any,
   userPreferredNodeOrder: string[],
-): IsInPreferredOrderResult => {
+): PreferredOrderResult => {
   let isValid = true;
   let msg = null;
   const preferredNodeOrder =

--- a/test/unit/rules/prefer-alphabetical-bundledDependencies.test.ts
+++ b/test/unit/rules/prefer-alphabetical-bundledDependencies.test.ts
@@ -15,7 +15,7 @@ describe('prefer-alphabetical-bundledDependencies Unit Tests', () => {
 
   describe('when package.json has node with an invalid order', () => {
     test('LintIssue object should be returned', () => {
-      jest.spyOn(alphabeticalSort, 'isInAlphabeticalOrder').mockReturnValue({
+      jest.spyOn(alphabeticalSort, 'checkAlphabeticalOrder').mockReturnValue({
         status: false,
         data: {
           invalidNode: 'semver',
@@ -39,14 +39,14 @@ describe('prefer-alphabetical-bundledDependencies Unit Tests', () => {
         'Your bundledDependencies are not in alphabetical order. Please move semver after chalk.',
       );
 
-      expect(alphabeticalSort.isInAlphabeticalOrder).toHaveBeenCalledTimes(1);
-      expect(alphabeticalSort.isInAlphabeticalOrder).toHaveBeenCalledWith(packageJsonData, nodeName);
+      expect(alphabeticalSort.checkAlphabeticalOrder).toHaveBeenCalledTimes(1);
+      expect(alphabeticalSort.checkAlphabeticalOrder).toHaveBeenCalledWith(packageJsonData, nodeName);
     });
   });
 
   describe('when package.json has node with a valid order', () => {
     test('true should be returned', () => {
-      jest.spyOn(alphabeticalSort, 'isInAlphabeticalOrder').mockReturnValue({
+      jest.spyOn(alphabeticalSort, 'checkAlphabeticalOrder').mockReturnValue({
         status: true,
         data: {
           invalidNode: null,
@@ -65,8 +65,8 @@ describe('prefer-alphabetical-bundledDependencies Unit Tests', () => {
 
       expect(response).toBeNull();
 
-      expect(alphabeticalSort.isInAlphabeticalOrder).toHaveBeenCalledTimes(1);
-      expect(alphabeticalSort.isInAlphabeticalOrder).toHaveBeenCalledWith(packageJsonData, nodeName);
+      expect(alphabeticalSort.checkAlphabeticalOrder).toHaveBeenCalledTimes(1);
+      expect(alphabeticalSort.checkAlphabeticalOrder).toHaveBeenCalledWith(packageJsonData, nodeName);
     });
   });
 

--- a/test/unit/rules/prefer-alphabetical-dependencies.test.ts
+++ b/test/unit/rules/prefer-alphabetical-dependencies.test.ts
@@ -15,7 +15,7 @@ describe('prefer-alphabetical-dependencies Unit Tests', () => {
 
   describe('when package.json has node with an invalid order', () => {
     test('LintIssue object should be returned', () => {
-      jest.spyOn(alphabeticalSort, 'isInAlphabeticalOrder').mockReturnValue({
+      jest.spyOn(alphabeticalSort, 'checkAlphabeticalOrder').mockReturnValue({
         status: false,
         data: {
           invalidNode: 'semver',
@@ -39,14 +39,14 @@ describe('prefer-alphabetical-dependencies Unit Tests', () => {
         'Your dependencies are not in alphabetical order. Please move semver after chalk.',
       );
 
-      expect(alphabeticalSort.isInAlphabeticalOrder).toHaveBeenCalledTimes(1);
-      expect(alphabeticalSort.isInAlphabeticalOrder).toHaveBeenCalledWith(packageJsonData, nodeName);
+      expect(alphabeticalSort.checkAlphabeticalOrder).toHaveBeenCalledTimes(1);
+      expect(alphabeticalSort.checkAlphabeticalOrder).toHaveBeenCalledWith(packageJsonData, nodeName);
     });
   });
 
   describe('when package.json has node with a valid order', () => {
     test('true should be returned', () => {
-      jest.spyOn(alphabeticalSort, 'isInAlphabeticalOrder').mockReturnValue({
+      jest.spyOn(alphabeticalSort, 'checkAlphabeticalOrder').mockReturnValue({
         status: true,
         data: {
           invalidNode: null,
@@ -65,8 +65,8 @@ describe('prefer-alphabetical-dependencies Unit Tests', () => {
 
       expect(response).toBeNull();
 
-      expect(alphabeticalSort.isInAlphabeticalOrder).toHaveBeenCalledTimes(1);
-      expect(alphabeticalSort.isInAlphabeticalOrder).toHaveBeenCalledWith(packageJsonData, nodeName);
+      expect(alphabeticalSort.checkAlphabeticalOrder).toHaveBeenCalledTimes(1);
+      expect(alphabeticalSort.checkAlphabeticalOrder).toHaveBeenCalledWith(packageJsonData, nodeName);
     });
   });
 

--- a/test/unit/rules/prefer-alphabetical-devDependencies.test.ts
+++ b/test/unit/rules/prefer-alphabetical-devDependencies.test.ts
@@ -15,7 +15,7 @@ describe('prefer-alphabetical-devDependencies Unit Tests', () => {
 
   describe('when package.json has node with an invalid order', () => {
     test('LintIssue object should be returned', () => {
-      jest.spyOn(alphabeticalSort, 'isInAlphabeticalOrder').mockReturnValue({
+      jest.spyOn(alphabeticalSort, 'checkAlphabeticalOrder').mockReturnValue({
         status: false,
         data: {
           invalidNode: 'semver',
@@ -39,14 +39,14 @@ describe('prefer-alphabetical-devDependencies Unit Tests', () => {
         'Your devDependencies are not in alphabetical order. Please move semver after chalk.',
       );
 
-      expect(alphabeticalSort.isInAlphabeticalOrder).toHaveBeenCalledTimes(1);
-      expect(alphabeticalSort.isInAlphabeticalOrder).toHaveBeenCalledWith(packageJsonData, nodeName);
+      expect(alphabeticalSort.checkAlphabeticalOrder).toHaveBeenCalledTimes(1);
+      expect(alphabeticalSort.checkAlphabeticalOrder).toHaveBeenCalledWith(packageJsonData, nodeName);
     });
   });
 
   describe('when package.json has node with a valid order', () => {
     test('true should be returned', () => {
-      jest.spyOn(alphabeticalSort, 'isInAlphabeticalOrder').mockReturnValue({
+      jest.spyOn(alphabeticalSort, 'checkAlphabeticalOrder').mockReturnValue({
         status: true,
         data: {
           invalidNode: null,
@@ -65,8 +65,8 @@ describe('prefer-alphabetical-devDependencies Unit Tests', () => {
 
       expect(response).toBeNull();
 
-      expect(alphabeticalSort.isInAlphabeticalOrder).toHaveBeenCalledTimes(1);
-      expect(alphabeticalSort.isInAlphabeticalOrder).toHaveBeenCalledWith(packageJsonData, nodeName);
+      expect(alphabeticalSort.checkAlphabeticalOrder).toHaveBeenCalledTimes(1);
+      expect(alphabeticalSort.checkAlphabeticalOrder).toHaveBeenCalledWith(packageJsonData, nodeName);
     });
   });
 

--- a/test/unit/rules/prefer-alphabetical-optionalDependencies.test.ts
+++ b/test/unit/rules/prefer-alphabetical-optionalDependencies.test.ts
@@ -15,7 +15,7 @@ describe('prefer-alphabetical-optionalDependencies Unit Tests', () => {
 
   describe('when package.json has node with an invalid order', () => {
     test('LintIssue object should be returned', () => {
-      jest.spyOn(alphabeticalSort, 'isInAlphabeticalOrder').mockReturnValue({
+      jest.spyOn(alphabeticalSort, 'checkAlphabeticalOrder').mockReturnValue({
         status: false,
         data: {
           invalidNode: 'semver',
@@ -39,14 +39,14 @@ describe('prefer-alphabetical-optionalDependencies Unit Tests', () => {
         'Your optionalDependencies are not in alphabetical order. Please move semver after chalk.',
       );
 
-      expect(alphabeticalSort.isInAlphabeticalOrder).toHaveBeenCalledTimes(1);
-      expect(alphabeticalSort.isInAlphabeticalOrder).toHaveBeenCalledWith(packageJsonData, nodeName);
+      expect(alphabeticalSort.checkAlphabeticalOrder).toHaveBeenCalledTimes(1);
+      expect(alphabeticalSort.checkAlphabeticalOrder).toHaveBeenCalledWith(packageJsonData, nodeName);
     });
   });
 
   describe('when package.json has node with a valid order', () => {
     test('true should be returned', () => {
-      jest.spyOn(alphabeticalSort, 'isInAlphabeticalOrder').mockReturnValue({
+      jest.spyOn(alphabeticalSort, 'checkAlphabeticalOrder').mockReturnValue({
         status: true,
         data: {
           invalidNode: null,
@@ -65,8 +65,8 @@ describe('prefer-alphabetical-optionalDependencies Unit Tests', () => {
 
       expect(response).toBeNull();
 
-      expect(alphabeticalSort.isInAlphabeticalOrder).toHaveBeenCalledTimes(1);
-      expect(alphabeticalSort.isInAlphabeticalOrder).toHaveBeenCalledWith(packageJsonData, nodeName);
+      expect(alphabeticalSort.checkAlphabeticalOrder).toHaveBeenCalledTimes(1);
+      expect(alphabeticalSort.checkAlphabeticalOrder).toHaveBeenCalledWith(packageJsonData, nodeName);
     });
   });
 

--- a/test/unit/rules/prefer-alphabetical-peerDependencies.test.ts
+++ b/test/unit/rules/prefer-alphabetical-peerDependencies.test.ts
@@ -15,7 +15,7 @@ describe('prefer-alphabetical-peerDependencies Unit Tests', () => {
 
   describe('when package.json has node with an invalid order', () => {
     test('LintIssue object should be returned', () => {
-      jest.spyOn(alphabeticalSort, 'isInAlphabeticalOrder').mockReturnValue({
+      jest.spyOn(alphabeticalSort, 'checkAlphabeticalOrder').mockReturnValue({
         status: false,
         data: {
           invalidNode: 'semver',
@@ -39,14 +39,14 @@ describe('prefer-alphabetical-peerDependencies Unit Tests', () => {
         'Your peerDependencies are not in alphabetical order. Please move semver after chalk.',
       );
 
-      expect(alphabeticalSort.isInAlphabeticalOrder).toHaveBeenCalledTimes(1);
-      expect(alphabeticalSort.isInAlphabeticalOrder).toHaveBeenCalledWith(packageJsonData, nodeName);
+      expect(alphabeticalSort.checkAlphabeticalOrder).toHaveBeenCalledTimes(1);
+      expect(alphabeticalSort.checkAlphabeticalOrder).toHaveBeenCalledWith(packageJsonData, nodeName);
     });
   });
 
   describe('when package.json has node with a valid order', () => {
     test('true should be returned', () => {
-      jest.spyOn(alphabeticalSort, 'isInAlphabeticalOrder').mockReturnValue({
+      jest.spyOn(alphabeticalSort, 'checkAlphabeticalOrder').mockReturnValue({
         status: true,
         data: {
           invalidNode: null,
@@ -65,8 +65,8 @@ describe('prefer-alphabetical-peerDependencies Unit Tests', () => {
 
       expect(response).toBeNull();
 
-      expect(alphabeticalSort.isInAlphabeticalOrder).toHaveBeenCalledTimes(1);
-      expect(alphabeticalSort.isInAlphabeticalOrder).toHaveBeenCalledWith(packageJsonData, nodeName);
+      expect(alphabeticalSort.checkAlphabeticalOrder).toHaveBeenCalledTimes(1);
+      expect(alphabeticalSort.checkAlphabeticalOrder).toHaveBeenCalledWith(packageJsonData, nodeName);
     });
   });
 

--- a/test/unit/rules/prefer-alphabetical-scripts.test.ts
+++ b/test/unit/rules/prefer-alphabetical-scripts.test.ts
@@ -15,7 +15,7 @@ describe('prefer-alphabetical-scripts Unit Tests', () => {
 
   describe('when package.json has node with an invalid order', () => {
     test('LintIssue object should be returned', () => {
-      jest.spyOn(alphabeticalSort, 'isInAlphabeticalOrder').mockReturnValue({
+      jest.spyOn(alphabeticalSort, 'checkAlphabeticalOrder').mockReturnValue({
         status: false,
         data: {
           invalidNode: 'test',
@@ -39,14 +39,14 @@ describe('prefer-alphabetical-scripts Unit Tests', () => {
         'Your scripts are not in alphabetical order. Please move test after start.',
       );
 
-      expect(alphabeticalSort.isInAlphabeticalOrder).toHaveBeenCalledTimes(1);
-      expect(alphabeticalSort.isInAlphabeticalOrder).toHaveBeenCalledWith(packageJsonData, nodeName);
+      expect(alphabeticalSort.checkAlphabeticalOrder).toHaveBeenCalledTimes(1);
+      expect(alphabeticalSort.checkAlphabeticalOrder).toHaveBeenCalledWith(packageJsonData, nodeName);
     });
   });
 
   describe('when package.json has node with a valid order', () => {
     test('true should be returned', () => {
-      jest.spyOn(alphabeticalSort, 'isInAlphabeticalOrder').mockReturnValue({
+      jest.spyOn(alphabeticalSort, 'checkAlphabeticalOrder').mockReturnValue({
         status: true,
         data: {
           invalidNode: null,
@@ -65,8 +65,8 @@ describe('prefer-alphabetical-scripts Unit Tests', () => {
 
       expect(response).toBeNull();
 
-      expect(alphabeticalSort.isInAlphabeticalOrder).toHaveBeenCalledTimes(1);
-      expect(alphabeticalSort.isInAlphabeticalOrder).toHaveBeenCalledWith(packageJsonData, nodeName);
+      expect(alphabeticalSort.checkAlphabeticalOrder).toHaveBeenCalledTimes(1);
+      expect(alphabeticalSort.checkAlphabeticalOrder).toHaveBeenCalledWith(packageJsonData, nodeName);
     });
   });
 

--- a/test/unit/validators/alphabetical-sort.test.ts
+++ b/test/unit/validators/alphabetical-sort.test.ts
@@ -1,7 +1,7 @@
 import * as alphabeticalSort from '../../../src/validators/alphabetical-sort';
 
 describe('alphabetical-sort Unit Tests', () => {
-  describe('isInAlphabeticalOrder method', () => {
+  describe('checkAlphabeticalOrder method', () => {
     describe('when the node exists in the package.json file and dependencies are in alpahbetical order', () => {
       test('true should be returned', () => {
         const packageJson = {
@@ -11,7 +11,7 @@ describe('alphabetical-sort Unit Tests', () => {
             'user-home': '^2.0.0',
           },
         };
-        const response = alphabeticalSort.isInAlphabeticalOrder(packageJson, 'devDependencies');
+        const response = alphabeticalSort.checkAlphabeticalOrder(packageJson, 'devDependencies');
 
         expect(response.status).toBe(true);
         expect(response.data.invalidNode).toBeNull();
@@ -28,7 +28,7 @@ describe('alphabetical-sort Unit Tests', () => {
             'user-home': '^2.0.0',
           },
         };
-        const response = alphabeticalSort.isInAlphabeticalOrder(packageJson, 'devDependencies');
+        const response = alphabeticalSort.checkAlphabeticalOrder(packageJson, 'devDependencies');
 
         expect(response.status).toBe(false);
         expect(response.data.invalidNode).toStrictEqual('semver');

--- a/test/unit/validators/property-order.test.ts
+++ b/test/unit/validators/property-order.test.ts
@@ -1,7 +1,7 @@
 import * as propertyOrder from '../../../src/validators/property-order';
 
 describe('property-order Unit Tests', () => {
-  describe('isInPreferredOrder method', () => {
+  describe('checkPreferredOrder method', () => {
     describe('when the properties in the package.json file are in the desired order', () => {
       test('true should be returned', () => {
         const packageJson = {
@@ -10,7 +10,7 @@ describe('property-order Unit Tests', () => {
           description: 'description',
         };
         const preferredOrder = ['name', 'version', 'description'];
-        const response = propertyOrder.isInPreferredOrder(packageJson, preferredOrder);
+        const response = propertyOrder.checkPreferredOrder(packageJson, preferredOrder);
 
         expect(response.status).toBe(true);
         expect(response.msg).toBeNull();
@@ -25,7 +25,7 @@ describe('property-order Unit Tests', () => {
           description: 'description',
         };
         const preferredOrder = [];
-        const response = propertyOrder.isInPreferredOrder(packageJson, preferredOrder);
+        const response = propertyOrder.checkPreferredOrder(packageJson, preferredOrder);
 
         expect(response.status).toBe(true);
         expect(response.msg).toBeNull();
@@ -39,7 +39,7 @@ describe('property-order Unit Tests', () => {
           version: '1.0.0',
         };
         const preferredOrder = ['name', 'version', 'description'];
-        const response = propertyOrder.isInPreferredOrder(packageJson, preferredOrder);
+        const response = propertyOrder.checkPreferredOrder(packageJson, preferredOrder);
 
         expect(response.status).toBe(true);
         expect(response.msg).toBeNull();
@@ -54,7 +54,7 @@ describe('property-order Unit Tests', () => {
           version: '1.0.0',
         };
         const preferredOrder = ['name', 'version', 'description'];
-        const response = propertyOrder.isInPreferredOrder(packageJson, preferredOrder);
+        const response = propertyOrder.checkPreferredOrder(packageJson, preferredOrder);
 
         expect(response.status).toBe(false);
         expect(response.msg).toStrictEqual('Please move "description" after "version".');
@@ -69,7 +69,7 @@ describe('property-order Unit Tests', () => {
           description: 'description',
         };
         const preferredOrder = ['name', 'version', 'description'];
-        const response = propertyOrder.isInPreferredOrder(packageJson, preferredOrder);
+        const response = propertyOrder.checkPreferredOrder(packageJson, preferredOrder);
 
         expect(response.status).toBe(false);
         expect(response.msg).toStrictEqual('Please move "version" after "name".');
@@ -84,7 +84,7 @@ describe('property-order Unit Tests', () => {
           description: 'description',
         };
         const preferredOrder = ['name', 'version', 'homepage', 'description'];
-        const response = propertyOrder.isInPreferredOrder(packageJson, preferredOrder);
+        const response = propertyOrder.checkPreferredOrder(packageJson, preferredOrder);
 
         expect(response.status).toBe(true);
         expect(response.msg).toBeNull();
@@ -100,7 +100,7 @@ describe('property-order Unit Tests', () => {
           homepage: 'https://github.com/tclindner/npm-package-json-lint',
         };
         const preferredOrder = ['name', 'version', 'description', 'keywords', 'homepage'];
-        const response = propertyOrder.isInPreferredOrder(packageJson, preferredOrder);
+        const response = propertyOrder.checkPreferredOrder(packageJson, preferredOrder);
 
         expect(response.status).toBe(true);
         expect(response.msg).toBeNull();
@@ -116,7 +116,7 @@ describe('property-order Unit Tests', () => {
           homepage: 'https://github.com/tclindner/npm-package-json-lint',
         };
         const preferredOrder = ['name', 'version', 'description', 'scripts', 'bin', 'keywords', 'homepage'];
-        const response = propertyOrder.isInPreferredOrder(packageJson, preferredOrder);
+        const response = propertyOrder.checkPreferredOrder(packageJson, preferredOrder);
 
         expect(response.status).toBe(true);
         expect(response.msg).toBeNull();
@@ -134,7 +134,7 @@ describe('property-order Unit Tests', () => {
           keywords: ['awesome'],
         };
         const preferredOrder = ['name', 'version', 'description', 'scripts', 'bin', 'keywords', 'homepage'];
-        const response = propertyOrder.isInPreferredOrder(packageJson, preferredOrder);
+        const response = propertyOrder.checkPreferredOrder(packageJson, preferredOrder);
 
         expect(response.status).toBe(false);
         expect(response.msg).toStrictEqual('Please move "homepage" after "keywords".');
@@ -151,7 +151,7 @@ describe('property-order Unit Tests', () => {
           keywords: ['word'],
         };
         const preferredOrder = ['name', 'version', 'description', 'scripts', 'bin', 'keywords', 'homepage'];
-        const response = propertyOrder.isInPreferredOrder(packageJson, preferredOrder);
+        const response = propertyOrder.checkPreferredOrder(packageJson, preferredOrder);
 
         expect(response.status).toBe(false);
         expect(response.msg).toStrictEqual('Please move "homepage" after "keywords".');
@@ -167,7 +167,7 @@ describe('property-order Unit Tests', () => {
           homepage: 'https://github.com/tclindner/npm-package-json-lint',
         };
         const preferredOrder = ['name', 'version', 'keywords', 'homepage'];
-        const response = propertyOrder.isInPreferredOrder(packageJson, preferredOrder);
+        const response = propertyOrder.checkPreferredOrder(packageJson, preferredOrder);
 
         expect(response.status).toBe(true);
         expect(response.msg).toBeNull();
@@ -183,7 +183,7 @@ describe('property-order Unit Tests', () => {
           homepage: 'https://github.com/tclindner/npm-package-json-lint',
         };
         const preferredOrder = ['version', 'keywords', 'homepage'];
-        const response = propertyOrder.isInPreferredOrder(packageJson, preferredOrder);
+        const response = propertyOrder.checkPreferredOrder(packageJson, preferredOrder);
 
         expect(response.status).toBe(true);
         expect(response.msg).toBeNull();


### PR DESCRIPTION
**Description of change**

Bumps `eslint-plugin-unicorn` from 69.0.0 to 70.0.0 (continuing the incremental major-version approach from #1882/#1891/#1892/#1893/#1894, to keep each bump's lint fallout small and reviewable).

**Fix for the new/changed rule in this release:**

- `consistent-boolean-name`: this rule now also flags the inverse case — names starting with an `is`/`has`/etc. prefix that don't actually return a boolean. Renamed two validators that return a `{status, ...}` result object rather than a plain boolean:
  - `alphabetical-sort.ts`: `isInAlphabeticalOrder` → `checkAlphabeticalOrder` (`IsInAlphabeticalOrderResult` → `AlphabeticalOrderResult`), updated across all 6 `prefer-alphabetical-*` rules and their tests.
  - `property-order.ts`: `isInPreferredOrder` → `checkPreferredOrder` (`IsInPreferredOrderResult` → `PreferredOrderResult`), updated in `prefer-property-order.ts` and its test.

Both are internal (not part of the public `api.ts` surface), so this is a same-file-tree-only rename with no consumer-facing impact.

Verified: build, full lint (0 errors), and full test suite (148/148 suites, 815/815 tests) all pass locally.

**Checklist**

- [x] Unit tests have been added (existing suite passes unchanged; no behavior changes introduced)
- [ ] Specific notes for documentation, if applicable


---
_Generated by [Claude Code](https://claude.ai/code/session_011CQXt16L3t5PKJSQxg9YRz)_