### PR TITLE
build(deps-dev): Bump eslint-plugin-unicorn from 71.0.0 to 72.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "eslint-plugin-import-x": "4.17.1",
         "eslint-plugin-jest": "29.15.5",
         "eslint-plugin-prettier": "5.5.6",
-        "eslint-plugin-unicorn": "71.0.0",
+        "eslint-plugin-unicorn": "72.0.0",
         "globals": "17.7.0",
         "jest": "30.4.2",
         "npm-package-json-lint-config-default": "9.0.1",
@@ -667,6 +667,20 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/css-tree": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/css-tree/-/css-tree-4.0.5.tgz",
+      "integrity": "sha512-iPmijIAq4hlIJB86PYmY/fcZORHtjphSqICDbwuw32A/JmkhZQ/K/6TjHE03zqf3n5yABpVcbRAMG8Mi9ojy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.29.0",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -3594,6 +3608,19 @@
         "node": ">=14"
       }
     },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -3872,18 +3899,20 @@
       }
     },
     "node_modules/eslint-plugin-unicorn": {
-      "version": "71.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-71.0.0.tgz",
-      "integrity": "sha512-9LAN/lIeEY8x1PsP10wOe1bFhNVJ4s3GWfy2FGiiZiKUd2JXVFKbjFaSVSWMKaVyKx1ulj3g5LMPKjWtvQntwg==",
+      "version": "72.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-72.0.0.tgz",
+      "integrity": "sha512-hqO6ksoOHO+ZhdseTuKRVQbx9U7PRO/cv8qAR1mctwzdVO2hYud8uS9luAhp43RJgziYgHAph8eHyipT8GL0ng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
+        "@eslint/css-tree": "^4.0.4",
         "browserslist": "^4.28.4",
         "change-case": "^5.4.4",
         "ci-info": "^4.4.0",
         "core-js-compat": "^3.49.0",
         "detect-indent": "^7.0.2",
+        "entities": "^4.5.0",
         "find-up-simple": "^1.0.1",
         "globals": "^17.7.0",
         "indent-string": "^5.0.0",
@@ -3894,7 +3923,8 @@
         "regjsparser": "^0.13.2",
         "reserved-identifiers": "^1.2.0",
         "semver": "^7.8.5",
-        "strip-indent": "^4.1.1"
+        "strip-indent": "^4.1.1",
+        "yaml": "^2.9.0"
       },
       "engines": {
         "node": ">=22"
@@ -5853,6 +5883,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.29.0.tgz",
+      "integrity": "sha512-pVxQFCcaYUEAH853+v7yoI/qzhxXSq1bTb9obMYGYAN1c3Hen+XDCEvr296XhstrwlSTNgOR7mCSD4JPjbJe5A==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/meow": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
@@ -7238,6 +7275,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
@@ -8356,6 +8403,22 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-import-x": "4.17.1",
     "eslint-plugin-jest": "29.15.5",
     "eslint-plugin-prettier": "5.5.6",
-    "eslint-plugin-unicorn": "71.0.0",
+    "eslint-plugin-unicorn": "72.0.0",
     "globals": "17.7.0",
     "jest": "30.4.2",
     "npm-package-json-lint-config-default": "9.0.1",

--- a/src/utils/plur.ts
+++ b/src/utils/plur.ts
@@ -6,7 +6,7 @@
  * @returns {string}              Pluralized word
  */
 export const plur = (singularWord: string, count: number): string => {
-  if (count > 1 || count === 0) {
+  if (count === 0 || count > 1) {
     return `${singularWord}s`;
   }
 


### PR DESCRIPTION
**Description of change**

Bumps `eslint-plugin-unicorn` from 71.0.0 to 72.0.0. This is the final hop of the incremental major-version bump chain started in #1882 (64.0.0 → 65.0.1) and continued through #1891/#1892/#1893/#1894/#1895/#1896 — this PR reaches the version the original Dependabot PR targeted.

**Fix for the new/changed rule in this release:**

- `prefer-simple-condition-first`: swapped the operand order in `plur.ts`'s `count > 1 || count === 0` to `count === 0 || count > 1`. Both operands are pure comparisons on the same variable with no side effects, so reordering doesn't change short-circuit behavior.

Verified: build, full lint (0 errors), and full test suite (148/148 suites, 815/815 tests) all pass locally.

**Checklist**

- [x] Unit tests have been added (existing suite passes unchanged; no behavior changes introduced)
- [ ] Specific notes for documentation, if applicable


---
_Generated by [Claude Code](https://claude.ai/code/session_011CQXt16L3t5PKJSQxg9YRz)_