### PR TITLE
fix: bundle ajv and ajv-errors to avoid cross-version codegen mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "ajv": "8.20.0",
-        "ajv-errors": "3.0.0",
         "chalk": "4.1.2",
         "cosmiconfig": "10.0.0",
         "debug": "4.4.3",
@@ -31,6 +29,8 @@
         "@eslint/js": "10.0.1",
         "@types/jest": "30.0.0",
         "@types/node": "26.2.0",
+        "ajv": "8.20.0",
+        "ajv-errors": "3.0.0",
         "eslint": "10.8.1",
         "eslint-config-prettier": "10.1.8",
         "eslint-config-tc": "28.0.3",
@@ -2736,6 +2736,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2752,6 +2753,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
       "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "ajv": "^8.0.1"
@@ -2761,6 +2763,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ansi-escapes": {
@@ -4143,6 +4146,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -4198,6 +4202,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
       "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6998,6 +7003,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -37,8 +37,6 @@
     "test:ci": "jest --runInBand"
   },
   "dependencies": {
-    "ajv": "8.20.0",
-    "ajv-errors": "3.0.0",
     "chalk": "4.1.2",
     "cosmiconfig": "10.0.0",
     "debug": "4.4.3",
@@ -53,6 +51,8 @@
     "validate-npm-package-name": "8.0.0"
   },
   "devDependencies": {
+    "ajv": "8.20.0",
+    "ajv-errors": "3.0.0",
     "@eslint/js": "10.0.1",
     "@types/jest": "30.0.0",
     "@types/node": "26.2.0",

--- a/src/config/ConfigSchema.ts
+++ b/src/config/ConfigSchema.ts
@@ -1,4 +1,8 @@
+// ajv and ajv-errors are bundled into dist/ by tsdown (see tsdown.config.ts) rather than
+// resolved from a consumer's node_modules at runtime, so they are devDependencies here.
+// eslint-disable-next-line import-x/no-extraneous-dependencies
 import Ajv from 'ajv';
+// eslint-disable-next-line import-x/no-extraneous-dependencies
 import ajvErrors from 'ajv-errors';
 
 /**

--- a/src/config/ConfigSchema.ts
+++ b/src/config/ConfigSchema.ts
@@ -1,5 +1,4 @@
-// ajv and ajv-errors are bundled into dist/ by tsdown (see tsdown.config.ts) rather than
-// resolved from a consumer's node_modules at runtime, so they are devDependencies here.
+// Ajv, ajv-errors, and their runtime dependency closure are bundled by tsdown.
 // eslint-disable-next-line import-x/no-extraneous-dependencies
 import Ajv from 'ajv';
 // eslint-disable-next-line import-x/no-extraneous-dependencies

--- a/test/integration/packed-consumer.test.js
+++ b/test/integration/packed-consumer.test.js
@@ -1,0 +1,143 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const {execFileSync, spawnSync} = require('node:child_process');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const {existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync} = require('node:fs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const {tmpdir} = require('node:os');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const path = require('node:path');
+
+const npmCliPath = process.env.npm_execpath;
+const systemNpmExecutable = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const npmExecutable = npmCliPath ? process.execPath : systemNpmExecutable;
+const projectRoot = path.resolve(__dirname, '../..');
+
+const createNpmEnvironment = (npmUserConfig) => {
+  const environment = {
+    ...process.env,
+    NO_UPDATE_NOTIFIER: '1',
+  };
+
+  delete environment.npm_config_allow_scripts;
+  delete environment.npm_config_strict_allow_scripts;
+  delete environment.npm_config_userconfig;
+
+  if (npmUserConfig) {
+    environment.NPM_CONFIG_USERCONFIG = npmUserConfig;
+  }
+
+  return environment;
+};
+
+const runNpm = (arguments_, cwd, npmUserConfig) =>
+  execFileSync(npmExecutable, npmCliPath ? [npmCliPath, ...arguments_] : arguments_, {
+    cwd,
+    encoding: 'utf8',
+    env: createNpmEnvironment(npmUserConfig),
+    shell: !npmCliPath && process.platform === 'win32',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+const readPackageVersion = (packageJsonPath) => JSON.parse(readFileSync(packageJsonPath, 'utf8')).version;
+
+const runPackedCli = (consumerDirectory) =>
+  spawnSync(
+    process.execPath,
+    [path.join(consumerDirectory, 'node_modules', 'npm-package-json-lint', 'dist', 'cli.js'), '--quiet', './package.json'],
+    {
+      cwd: consumerDirectory,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        FORCE_COLOR: '0',
+      },
+    },
+  );
+
+const runPackedApi = (consumerDirectory) =>
+  spawnSync(
+    process.execPath,
+    [
+      '--eval',
+      `const {NpmPackageJsonLint} = require('npm-package-json-lint');
+const result = new NpmPackageJsonLint({cwd: process.cwd(), patterns: ['./package.json']}).lint();
+if (result.errorCount > 0) process.exitCode = 2;`,
+    ],
+    {
+      cwd: consumerDirectory,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        FORCE_COLOR: '0',
+      },
+    },
+  );
+
+describe('packed consumer', () => {
+  test('entrypoints work in clean and conflicting Ajv dependency trees', () => {
+    const temporaryRoot = mkdtempSync(path.join(tmpdir(), 'npm-package-json-lint-packed-consumer-'));
+
+    try {
+      const npmUserConfig = path.join(temporaryRoot, '.npmrc');
+      writeFileSync(npmUserConfig, '');
+
+      const packMetadata = JSON.parse(runNpm(['pack', '--json', '--pack-destination', temporaryRoot], projectRoot));
+      const packEntries = Array.isArray(packMetadata) ? packMetadata : Object.values(packMetadata);
+
+      expect(packEntries).toHaveLength(1);
+
+      const [packEntry] = packEntries;
+      expect(packEntry).toStrictEqual(expect.objectContaining({filename: expect.any(String)}));
+
+      const tarballPath = path.join(temporaryRoot, packEntry.filename);
+      writeFileSync(
+        path.join(temporaryRoot, 'package.json'),
+        `${JSON.stringify(
+          {
+            name: 'npm-package-json-lint-packed-consumer',
+            version: '1.0.0',
+            private: true,
+            npmpackagejsonlint: {
+              rules: {
+                'bin-type': 'error',
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+
+      runNpm(
+        ['install', '--ignore-scripts', '--no-audit', '--no-fund', '--package-lock=false', tarballPath],
+        temporaryRoot,
+        npmUserConfig,
+      );
+
+      expect(existsSync(path.join(temporaryRoot, 'node_modules', 'ajv'))).toBe(false);
+      expect(existsSync(path.join(temporaryRoot, 'node_modules', 'ajv-errors'))).toBe(false);
+      expect(existsSync(path.join(temporaryRoot, 'node_modules', 'fast-deep-equal'))).toBe(false);
+      expect(existsSync(path.join(temporaryRoot, 'node_modules', 'fast-uri'))).toBe(false);
+      expect(existsSync(path.join(temporaryRoot, 'node_modules', 'json-schema-traverse'))).toBe(false);
+
+      const cleanResult = runPackedCli(temporaryRoot);
+      expect(cleanResult).toStrictEqual(expect.objectContaining({status: 0, stderr: ''}));
+      const cleanApiResult = runPackedApi(temporaryRoot);
+      expect(cleanApiResult).toStrictEqual(expect.objectContaining({status: 0, stderr: ''}));
+
+      runNpm(
+        ['install', '--ignore-scripts', '--no-audit', '--no-fund', '--package-lock=false', '--save-exact', 'ajv@8.18.0'],
+        temporaryRoot,
+        npmUserConfig,
+      );
+
+      expect(readPackageVersion(path.join(temporaryRoot, 'node_modules', 'ajv', 'package.json'))).toBe('8.18.0');
+      const conflictingResult = runPackedCli(temporaryRoot);
+      expect(conflictingResult).toStrictEqual(expect.objectContaining({status: 0, stderr: ''}));
+      const conflictingApiResult = runPackedApi(temporaryRoot);
+      expect(conflictingApiResult).toStrictEqual(expect.objectContaining({status: 0, stderr: ''}));
+    } finally {
+      rmSync(temporaryRoot, {recursive: true, force: true});
+    }
+  }, 120_000);
+});

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,6 +1,8 @@
 // eslint-disable-next-line import-x/no-extraneous-dependencies
 import {defineConfig} from 'tsdown';
 
+const bundledAjvDependencies = [/^(?:ajv(?:-errors)?|fast-deep-equal|fast-uri|json-schema-traverse)(?:\/|$)/];
+
 export default defineConfig([
   {
     entry: './src/rules/*.ts',
@@ -44,11 +46,12 @@ export default defineConfig([
       // If a consumer's dependency tree resolves a different (but semver-
       // compatible) copy of ajv for ajv-errors than the one used to create
       // that instance, schema compilation silently produces malformed code.
-      // Bundling both removes any dependence on runtime module resolution.
-      // Match subpath imports too (e.g. `ajv/dist/compile/codegen`, which
-      // ajv-errors imports directly): a bare 'ajv'/'ajv-errors' entry only
-      // matches the package root and leaves those subpaths external.
-      alwaysBundle: [/^ajv(-errors)?(\/|$)/],
+      // Bundle both packages and Ajv's runtime dependency closure so the
+      // published artifact is independent of consumer module resolution.
+      // The regex also matches subpath imports such as Ajv's codegen modules.
+      alwaysBundle: bundledAjvDependencies,
+      // neverBundle already makes alwaysBundle the explicit bundled set.
+      onlyBundle: false,
     },
 
     // This ensures rules stay in dist/rules/ and API/CLI stay in dist/
@@ -72,7 +75,8 @@ export default defineConfig([
     deps: {
       neverBundle: true,
       // See the comment in the api.ts config above.
-      alwaysBundle: [/^ajv(-errors)?(\/|$)/],
+      alwaysBundle: bundledAjvDependencies,
+      onlyBundle: false,
     },
 
     // This ensures rules stay in dist/rules/ and API/CLI stay in dist/

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -18,7 +18,7 @@ export default defineConfig([
     // External Dependencies
     // Replaces esbuild-node-externals plugin
     deps: {
-      skipNodeModulesBundle: true,
+      neverBundle: true,
     },
 
     // This ensures rules stay in dist/rules/ and API/CLI stay in dist/
@@ -39,7 +39,16 @@ export default defineConfig([
     // External Dependencies
     // Replaces esbuild-node-externals plugin
     deps: {
-      skipNodeModulesBundle: true,
+      neverBundle: true,
+      // ajv-errors patches internals of the exact Ajv instance it is given.
+      // If a consumer's dependency tree resolves a different (but semver-
+      // compatible) copy of ajv for ajv-errors than the one used to create
+      // that instance, schema compilation silently produces malformed code.
+      // Bundling both removes any dependence on runtime module resolution.
+      // Match subpath imports too (e.g. `ajv/dist/compile/codegen`, which
+      // ajv-errors imports directly): a bare 'ajv'/'ajv-errors' entry only
+      // matches the package root and leaves those subpaths external.
+      alwaysBundle: [/^ajv(-errors)?(\/|$)/],
     },
 
     // This ensures rules stay in dist/rules/ and API/CLI stay in dist/
@@ -61,7 +70,9 @@ export default defineConfig([
     // External Dependencies
     // Replaces esbuild-node-externals plugin
     deps: {
-      skipNodeModulesBundle: true,
+      neverBundle: true,
+      // See the comment in the api.ts config above.
+      alwaysBundle: [/^ajv(-errors)?(\/|$)/],
     },
 
     // This ensures rules stay in dist/rules/ and API/CLI stay in dist/


### PR DESCRIPTION
ajv-errors patches the exact Ajv instance it is given by importing ajv's
code-generation internals (e.g. ajv/dist/compile/codegen) directly, so it
requires that both come from the same physical copy of ajv. Previously
those internals were left as runtime requires resolved from a consumer's
node_modules, so if a differently-hoisted (but semver-compatible) copy of
ajv ended up alongside ajv-errors, schema compilation produced malformed
generated code and crashed (#1921).

Bundle ajv and ajv-errors (including their subpath imports) into dist/
via tsdown so the shipped code is self-contained, and move them to
devDependencies since consumers no longer need to install them.

Fixes #1921