### PR TITLE
fix: bundle Ajv runtime dependency closure

### DIFF
--- a/src/config/ConfigSchema.ts
+++ b/src/config/ConfigSchema.ts
@@ -1,5 +1,4 @@
-// ajv and ajv-errors are bundled into dist/ by tsdown (see tsdown.config.ts) rather than
-// resolved from a consumer's node_modules at runtime, so they are devDependencies here.
+// Ajv, ajv-errors, and their runtime dependency closure are bundled by tsdown.
 // eslint-disable-next-line import-x/no-extraneous-dependencies
 import Ajv from 'ajv';
 // eslint-disable-next-line import-x/no-extraneous-dependencies

--- a/test/integration/packed-consumer.test.js
+++ b/test/integration/packed-consumer.test.js
@@ -1,0 +1,143 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const {execFileSync, spawnSync} = require('node:child_process');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const {existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync} = require('node:fs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const {tmpdir} = require('node:os');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const path = require('node:path');
+
+const npmCliPath = process.env.npm_execpath;
+const systemNpmExecutable = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const npmExecutable = npmCliPath ? process.execPath : systemNpmExecutable;
+const projectRoot = path.resolve(__dirname, '../..');
+
+const createNpmEnvironment = (npmUserConfig) => {
+  const environment = {
+    ...process.env,
+    NO_UPDATE_NOTIFIER: '1',
+  };
+
+  delete environment.npm_config_allow_scripts;
+  delete environment.npm_config_strict_allow_scripts;
+  delete environment.npm_config_userconfig;
+
+  if (npmUserConfig) {
+    environment.NPM_CONFIG_USERCONFIG = npmUserConfig;
+  }
+
+  return environment;
+};
+
+const runNpm = (arguments_, cwd, npmUserConfig) =>
+  execFileSync(npmExecutable, npmCliPath ? [npmCliPath, ...arguments_] : arguments_, {
+    cwd,
+    encoding: 'utf8',
+    env: createNpmEnvironment(npmUserConfig),
+    shell: !npmCliPath && process.platform === 'win32',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+const readPackageVersion = (packageJsonPath) => JSON.parse(readFileSync(packageJsonPath, 'utf8')).version;
+
+const runPackedCli = (consumerDirectory) =>
+  spawnSync(
+    process.execPath,
+    [path.join(consumerDirectory, 'node_modules', 'npm-package-json-lint', 'dist', 'cli.js'), '--quiet', './package.json'],
+    {
+      cwd: consumerDirectory,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        FORCE_COLOR: '0',
+      },
+    },
+  );
+
+const runPackedApi = (consumerDirectory) =>
+  spawnSync(
+    process.execPath,
+    [
+      '--eval',
+      `const {NpmPackageJsonLint} = require('npm-package-json-lint');
+const result = new NpmPackageJsonLint({cwd: process.cwd(), patterns: ['./package.json']}).lint();
+if (result.errorCount > 0) process.exitCode = 2;`,
+    ],
+    {
+      cwd: consumerDirectory,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        FORCE_COLOR: '0',
+      },
+    },
+  );
+
+describe('packed consumer', () => {
+  test('entrypoints work in clean and conflicting Ajv dependency trees', () => {
+    const temporaryRoot = mkdtempSync(path.join(tmpdir(), 'npm-package-json-lint-packed-consumer-'));
+
+    try {
+      const npmUserConfig = path.join(temporaryRoot, '.npmrc');
+      writeFileSync(npmUserConfig, '');
+
+      const packMetadata = JSON.parse(runNpm(['pack', '--json', '--pack-destination', temporaryRoot], projectRoot));
+      const packEntries = Array.isArray(packMetadata) ? packMetadata : Object.values(packMetadata);
+
+      expect(packEntries).toHaveLength(1);
+
+      const [packEntry] = packEntries;
+      expect(packEntry).toStrictEqual(expect.objectContaining({filename: expect.any(String)}));
+
+      const tarballPath = path.join(temporaryRoot, packEntry.filename);
+      writeFileSync(
+        path.join(temporaryRoot, 'package.json'),
+        `${JSON.stringify(
+          {
+            name: 'npm-package-json-lint-packed-consumer',
+            version: '1.0.0',
+            private: true,
+            npmpackagejsonlint: {
+              rules: {
+                'bin-type': 'error',
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+
+      runNpm(
+        ['install', '--ignore-scripts', '--no-audit', '--no-fund', '--package-lock=false', tarballPath],
+        temporaryRoot,
+        npmUserConfig,
+      );
+
+      expect(existsSync(path.join(temporaryRoot, 'node_modules', 'ajv'))).toBe(false);
+      expect(existsSync(path.join(temporaryRoot, 'node_modules', 'ajv-errors'))).toBe(false);
+      expect(existsSync(path.join(temporaryRoot, 'node_modules', 'fast-deep-equal'))).toBe(false);
+      expect(existsSync(path.join(temporaryRoot, 'node_modules', 'fast-uri'))).toBe(false);
+      expect(existsSync(path.join(temporaryRoot, 'node_modules', 'json-schema-traverse'))).toBe(false);
+
+      const cleanResult = runPackedCli(temporaryRoot);
+      expect(cleanResult).toStrictEqual(expect.objectContaining({status: 0, stderr: ''}));
+      const cleanApiResult = runPackedApi(temporaryRoot);
+      expect(cleanApiResult).toStrictEqual(expect.objectContaining({status: 0, stderr: ''}));
+
+      runNpm(
+        ['install', '--ignore-scripts', '--no-audit', '--no-fund', '--package-lock=false', '--save-exact', 'ajv@8.18.0'],
+        temporaryRoot,
+        npmUserConfig,
+      );
+
+      expect(readPackageVersion(path.join(temporaryRoot, 'node_modules', 'ajv', 'package.json'))).toBe('8.18.0');
+      const conflictingResult = runPackedCli(temporaryRoot);
+      expect(conflictingResult).toStrictEqual(expect.objectContaining({status: 0, stderr: ''}));
+      const conflictingApiResult = runPackedApi(temporaryRoot);
+      expect(conflictingApiResult).toStrictEqual(expect.objectContaining({status: 0, stderr: ''}));
+    } finally {
+      rmSync(temporaryRoot, {recursive: true, force: true});
+    }
+  }, 120_000);
+});

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,6 +1,8 @@
 // eslint-disable-next-line import-x/no-extraneous-dependencies
 import {defineConfig} from 'tsdown';
 
+const bundledAjvDependencies = [/^(?:ajv(?:-errors)?|fast-deep-equal|fast-uri|json-schema-traverse)(?:\/|$)/];
+
 export default defineConfig([
   {
     entry: './src/rules/*.ts',
@@ -44,11 +46,12 @@ export default defineConfig([
       // If a consumer's dependency tree resolves a different (but semver-
       // compatible) copy of ajv for ajv-errors than the one used to create
       // that instance, schema compilation silently produces malformed code.
-      // Bundling both removes any dependence on runtime module resolution.
-      // Match subpath imports too (e.g. `ajv/dist/compile/codegen`, which
-      // ajv-errors imports directly): a bare 'ajv'/'ajv-errors' entry only
-      // matches the package root and leaves those subpaths external.
-      alwaysBundle: [/^ajv(-errors)?(\/|$)/],
+      // Bundle both packages and Ajv's runtime dependency closure so the
+      // published artifact is independent of consumer module resolution.
+      // The regex also matches subpath imports such as Ajv's codegen modules.
+      alwaysBundle: bundledAjvDependencies,
+      // neverBundle already makes alwaysBundle the explicit bundled set.
+      onlyBundle: false,
     },
 
     // This ensures rules stay in dist/rules/ and API/CLI stay in dist/
@@ -72,7 +75,8 @@ export default defineConfig([
     deps: {
       neverBundle: true,
       // See the comment in the api.ts config above.
-      alwaysBundle: [/^ajv(-errors)?(\/|$)/],
+      alwaysBundle: bundledAjvDependencies,
+      onlyBundle: false,
     },
 
     // This ensures rules stay in dist/rules/ and API/CLI stay in dist/


### PR DESCRIPTION
## Summary

- bundle `ajv`, `ajv-errors`, and Ajv's imported runtime dependency closure into both published entrypoints
- keep the Ajv implementation in `devDependencies`, leaving the packed artifact independent of consumer module resolution
- add a packed-artifact regression test for the API and CLI in both a clean install and a consumer with `ajv@8.18.0`

## Why

The current #1922 tarball fails in a clean consumer before it reaches the original mismatch scenario:

```text
Error: Cannot find module 'fast-deep-equal'
Require stack:
- node_modules/npm-package-json-lint/dist/cli.js
```

`alwaysBundle` includes Ajv and ajv-errors, but `neverBundle: true` externalizes Ajv's imported runtime dependencies. Moving Ajv to `devDependencies` therefore removes the modules those emitted imports require.

Keeping Ajv as a production dependency would make a flattened npm installation pass, but it would still rely on undeclared transitive dependencies being visible from the bundled file. That is not a valid boundary for isolated dependency trees such as pnpm's. This PR instead adds the imported closure—`fast-deep-equal`, `fast-uri`, and `json-schema-traverse`—to the explicit bundle set. The packed consumer installs no runtime Ajv packages and succeeds even when the consumer installs its own `ajv@8.18.0`.

## Validation

- clean Ubuntu checkout, Node 22/npm 10: `npm ci` and `npm test` — 149 suites and 816 tests passed
- packed API and CLI regression passed on:
  - Node 22.21.1 / npm 10.9.4
  - Node 24.18.1 / npm 11.16.0
  - Node 26.7.0 / npm 12.0.2
- `npm run lint` — 0 errors; existing warning baseline remains
- `git diff --check`

This is intentionally based on `claude/github-issue-1921-lkmz2v` so it can be merged directly into #1922.