### PR TITLE
docs: Add v10 to v11 migration guide and fix documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@
   * [Custom Configuration](#custom-configuration)
   * [Local Development](#local-development)
   * [Documentation](#documentation)
+  * [Migrating from v10.x.x to 11.x.x](#migrating-from-v10xx-to-11xx)
+  * [Migrating from v9.x.x to 10.x.x](#migrating-from-v9xx-to-10xx)
+  * [Migrating from v8.x.x to 9.x.x](#migrating-from-v8xx-to-9xx)
+  * [Migrating from v7.x.x to 8.x.x](#migrating-from-v7xx-to-8xx)
+  * [Migrating from v6.x.x to 7.x.x](#migrating-from-v6xx-to-7xx)
   * [Migrating from v5.x.x to 6.x.x](#migrating-from-v5xx-to-6xx)
   * [Migrating from v4.x.x to 5.x.x](#migrating-from-v4xx-to-5xx)
   * [Migrating from v3.x.x to 4.x.x](#migrating-from-v3xx-to-4xx)
@@ -62,7 +67,7 @@ First thing first, let's make sure you have the necessary pre-requisites.
 
 #### Node
 
-* [Node.js](https://nodejs.org/) - v20.0.0+
+* [Node.js](https://nodejs.org/) - v22.0.0+
 * [npm](http://npmjs.com) - v10.0.0+
 
 ### Use the cli
@@ -116,6 +121,10 @@ Follow these steps to get your local environement set up to allow you to contrib
 Quick links
 
 [CLI commands and configuration](https://npmpackagejsonlint.org/docs/cli) | [Node.js API](https://npmpackagejsonlint.org/docs/api) | [Integrations](https://npmpackagejsonlint.org/docs/integrations)
+
+## Migrating from v10.x.x to 11.x.x
+
+Please see the [migration guide](https://npmpackagejsonlint.org/docs/v10-to-v11).
 
 ## Migrating from v9.x.x to 10.x.x
 

--- a/website/docs/rules.md
+++ b/website/docs/rules.md
@@ -169,11 +169,11 @@ Rules allow npm-package-json-lint to be fully customizable. npm-package-json-lin
 
 > Generates an error if the node is present
 
-* [prefer-no-bin](rules/disallowed-nodes/prefer-no-bin)
-* [prefer-no-contributors](rules/disallowed-nodes/prefer-no-contributors)
-* [prefer-no-dependencies](rules/disallowed-nodes/prefer-no-dependencies)
-* [prefer-no-devDependencies](rules/disallowed-nodes/prefer-no-devDependencies)
-* [prefer-no-engineStrict](rules/disallowed-nodes/prefer-no-engineStrict)
-* [prefer-no-main](rules/disallowed-nodes/prefer-no-main)
-* [prefer-no-optionalDependencies](rules/disallowed-nodes/prefer-no-optionalDependencies)
-* [prefer-no-peerDependencies](rules/disallowed-nodes/prefer-no-peerDependencies)
+* [prefer-no-bin](rules/disallowed-nodes/prefer-no-bin.md)
+* [prefer-no-contributors](rules/disallowed-nodes/prefer-no-contributors.md)
+* [prefer-no-dependencies](rules/disallowed-nodes/prefer-no-dependencies.md)
+* [prefer-no-devDependencies](rules/disallowed-nodes/prefer-no-devDependencies.md)
+* [prefer-no-engineStrict](rules/disallowed-nodes/prefer-no-engineStrict.md)
+* [prefer-no-main](rules/disallowed-nodes/prefer-no-main.md)
+* [prefer-no-optionalDependencies](rules/disallowed-nodes/prefer-no-optionalDependencies.md)
+* [prefer-no-peerDependencies](rules/disallowed-nodes/prefer-no-peerDependencies.md)

--- a/website/docs/rules/required-node/require-types.md
+++ b/website/docs/rules/required-node/require-types.md
@@ -35,7 +35,7 @@ Enabling this rule will result in an error being generated if `types` is missing
 
 ## Related
 
-[require-typings](rules/required-node/require-typings.md)
+[require-typings](require-typings.md)
 
 ## Notes
 

--- a/website/docs/rules/required-node/require-typings.md
+++ b/website/docs/rules/required-node/require-typings.md
@@ -35,7 +35,7 @@ Enabling this rule will result in an error being generated if `typings` is missi
 
 ## Related
 
-[require-types](rules/required-node/require-typings.md)
+[require-types](require-types.md)
 
 ## Notes
 

--- a/website/docs/v10-to-v11.md
+++ b/website/docs/v10-to-v11.md
@@ -1,0 +1,16 @@
+---
+id: v10-to-v11
+title: v10 to v11 Migration Guide
+---
+
+v11.0.0 Migration Guide
+
+## `--allowEmptyTargets` CLI option removed
+
+The `--allowEmptyTargets` CLI option has been removed. Previously, running the CLI without any lint targets would error unless `--allowEmptyTargets` was passed, in which case it would exit cleanly without linting anything.
+
+As of v11, running the CLI without any lint targets no longer errors. Instead, a warning is printed and the lint targets default to the current working directory (`.`).
+
+If you were relying on `--allowEmptyTargets` to exit cleanly with no targets, you will now need to explicitly pass a pattern that matches no files, or update your tooling to avoid invoking the CLI without targets.
+
+Please see the [release notes](https://github.com/tclindner/npm-package-json-lint/releases/tag/v11.0.0) for additional changes introduced in v11.0.0.

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -19,6 +19,7 @@
       "related-projects"
     ],
     "Migration Guides": [
+      "v10-to-v11",
       "v9-to-v10",
       "v8-to-v9",
       "v7-to-v8",


### PR DESCRIPTION
**Description of change**

This PR updates documentation for the v11 release:

1. **Added v10 to v11 migration guide** (`website/docs/v10-to-v11.md`) documenting the removal of the `--allowEmptyTargets` CLI option and its replacement behavior
2. **Fixed documentation links** in `website/docs/rules.md` by adding `.md` extensions to disallowed-nodes rule links for proper Docusaurus routing
3. **Fixed relative links** in rule documentation (`require-types.md` and `require-typings.md`) to use relative paths instead of absolute paths
4. **Updated Node.js requirement** in README from v20.0.0+ to v22.0.0+
5. **Added migration guide links** to README table of contents for v10→v11, v9→v10, v8→v9, v7→v8, and v6→v7
6. **Updated sidebars.json** to include the new v10-to-v11 migration guide in the documentation structure

**Checklist**

  - [ ] Unit tests have been added
  - [ ] Specific notes for documentation, if applicable - Documentation updates only, no code changes requiring tests

https://claude.ai/code/session_011RwcvnBJhgLsYjirwEDj2y